### PR TITLE
Add git_blame / git_blame_hunks table functions (closes #18)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
-set(EXTENSION_SOURCES src/duck_tails_extension.cpp src/git_filesystem.cpp src/git_functions.cpp src/git_log.cpp src/git_path.cpp src/git_utils.cpp src/git_context_manager.cpp src/git_tree.cpp src/git_parents.cpp src/git_branches.cpp src/git_tags.cpp src/git_read.cpp src/git_uri.cpp src/text_diff.cpp src/git_history.cpp src/git_status.cpp src/git_diff_tree.cpp)
+set(EXTENSION_SOURCES src/duck_tails_extension.cpp src/git_filesystem.cpp src/git_functions.cpp src/git_log.cpp src/git_path.cpp src/git_utils.cpp src/git_context_manager.cpp src/git_tree.cpp src/git_parents.cpp src/git_branches.cpp src/git_tags.cpp src/git_read.cpp src/git_uri.cpp src/text_diff.cpp src/git_history.cpp src/git_status.cpp src/git_diff_tree.cpp src/git_blame.cpp)
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})

--- a/docs/reference/git_blame.md
+++ b/docs/reference/git_blame.md
@@ -1,0 +1,143 @@
+# git_blame
+
+Return line-level authorship ("blame") for a file at a specific revision.
+Analogous to `git blame <rev> -- <path>`, but as a composable DuckDB table.
+
+Two output shapes are available:
+
+- `git_blame` — one row per line of the file, with `line_content`. Best for
+  joining against AST line ranges or per-line analysis.
+- `git_blame_hunks` — one row per libgit2 blame hunk (contiguous range of
+  lines from the same commit). Cheaper if you don't need line content.
+
+Both come in a static form and an `_each` LATERAL variant.
+
+## Syntax
+
+```sql
+git_blame(file_path_or_uri)
+git_blame(file_path_or_uri, revision := 'HEAD', repo_path := '.')
+
+git_blame_hunks(file_path_or_uri)
+git_blame_hunks(file_path_or_uri, revision := 'HEAD', repo_path := '.')
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| (positional) | VARCHAR | — | Either a `git://` URI that embeds the repo, file, and revision, or a plain file path. |
+| `repo_path` | VARCHAR | `.` | Repository path. Ignored when the positional is a `git://` URI. |
+| `revision` | VARCHAR | `HEAD` | Revision to blame at (SHA, branch, tag, or `HEAD~N`). |
+| `min_line` | BIGINT | 1 | Lower bound for lines to blame (1-indexed, inclusive). |
+| `max_line` | BIGINT | last line | Upper bound for lines to blame (inclusive). |
+| `ignore_whitespace` | BOOLEAN | `false` | Sets libgit2's `GIT_BLAME_IGNORE_WHITESPACE`. |
+| `use_mailmap` | BOOLEAN | `false` | Sets libgit2's `GIT_BLAME_USE_MAILMAP`. |
+| `first_parent` | BOOLEAN | `false` | Sets libgit2's `GIT_BLAME_FIRST_PARENT`. |
+
+## Output — `git_blame`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `repo_path` | VARCHAR | Absolute repository path |
+| `file_path` | VARCHAR | Path within the repository |
+| `file_ext` | VARCHAR | File extension |
+| `revision` | VARCHAR | Revision requested |
+| `line_number` | BIGINT | 1-indexed line in the file at `revision` |
+| `line_content` | VARCHAR | Text of that line; NULL for binary files |
+| `commit_hash` | VARCHAR | Commit that last touched this line |
+| `author_name` | VARCHAR | Author of `commit_hash` |
+| `author_email` | VARCHAR | Author email |
+| `author_date` | TIMESTAMP | Author timestamp |
+| `orig_commit_hash` | VARCHAR | Commit where this line was introduced |
+| `orig_path` | VARCHAR | Path in `orig_commit_hash` (same as `file_path` unless libgit2 detected a rename) |
+| `orig_line_number` | BIGINT | Line number in `orig_path` at `orig_commit_hash` |
+| `boundary` | BOOLEAN | True if the hunk reached the oldest commit boundary |
+
+## Output — `git_blame_hunks`
+
+Same columns as `git_blame` except `line_number`/`line_content`/`orig_line_number`
+are replaced with:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `start_line` | BIGINT | 1-indexed first line of the hunk |
+| `line_count` | BIGINT | Number of lines in the hunk |
+| `orig_start_line` | BIGINT | Start line in `orig_path` at `orig_commit_hash` |
+
+## Examples
+
+### Basic blame
+
+```sql
+SELECT line_number, author_name, line_content
+FROM git_blame('src/auth.py', repo_path := '.');
+```
+
+### Using a git:// URI
+
+```sql
+SELECT line_number, author_name
+FROM git_blame('git://src/auth.py@HEAD');
+```
+
+### Restrict to a line range (AST node)
+
+```sql
+SELECT line_number, commit_hash, author_name
+FROM git_blame('src/auth.py', min_line := 42, max_line := 57);
+```
+
+### Hunk view
+
+```sql
+SELECT start_line, line_count, commit_hash, author_date
+FROM git_blame_hunks('src/auth.py')
+ORDER BY start_line;
+```
+
+## LATERAL variants
+
+### Blame many files in one query
+
+```sql
+SELECT t.file_path, b.line_number, b.author_name
+FROM git_tree('HEAD') t,
+     LATERAL git_blame_each(t.git_uri) b
+WHERE t.file_ext = '.py';
+```
+
+### Blame the same file across a commit history
+
+```sql
+SELECT l.commit_hash, l.author_date, b.author_name
+FROM git_log() l,
+     LATERAL git_blame_each('src/auth.py', l.commit_hash) b
+WHERE b.line_number = 1
+LIMIT 10;
+```
+
+### Join against an AST table (pluckit-style)
+
+```sql
+SELECT a.node_id, b.author_name, b.author_date
+FROM my_ast_nodes a,
+     LATERAL git_blame_each(
+         a.file_path,
+         min_line := a.start_line,
+         max_line := a.end_line) b;
+```
+
+## Notes
+
+- **Rename tracking across files** is defined by libgit2's
+  `GIT_BLAME_TRACK_COPIES_*` flags but those are currently unimplemented in
+  libgit2. `orig_path` will almost always equal `file_path` until a future
+  libgit2 release. `git_blame` does not expose those flags today.
+- **Binary files** return `line_content` as NULL in `git_blame`. Use
+  `git_blame_hunks` if you want authorship without line content.
+- **Very long lines** (e.g. minified JS) are returned in full in `line_content`.
+  Use `min_line`/`max_line` to restrict blame to a manageable range.
+- `min_line`/`max_line` are passed directly to libgit2, so restricting a range
+  is cheap — the blame computation itself only walks commits that touched the
+  requested lines.

--- a/docs/superpowers/plans/2026-04-11-git-blame.md
+++ b/docs/superpowers/plans/2026-04-11-git-blame.md
@@ -1,0 +1,1955 @@
+# git_blame Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `git_blame` / `git_blame_hunks` table functions and `_each` LATERAL variants so DuckDB queries can compute line-level authorship against a git repository, matching the spec at `docs/superpowers/specs/2026-04-11-git-blame-design.md`.
+
+**Architecture:** A single new source file `src/git_blame.cpp` that wraps libgit2's `git_blame_file` API and exposes two output shapes (per-line rows and per-hunk rows) via a shared `CollectBlameRows` helper. Both shapes come in a static form (for direct calls) and a LATERAL `_each` form (for LATERAL joins). Named parameters (`repo_path`, `revision`, `min_line`, `max_line`, `ignore_whitespace`, `use_mailmap`, `first_parent`) configure libgit2's `git_blame_options` directly.
+
+**Tech Stack:** C++ (DuckDB extension), libgit2 (`git_blame_file` / `git_blame_get_hunk_byindex`), DuckDB SQL logic test framework.
+
+---
+
+## Preflight
+
+Before starting, ensure the test fixtures are extracted so blame tests have a real repo to target:
+
+```bash
+bash test/fixtures/setup_fixtures.sh setup
+ls test/tmp/main-repo/README.md
+```
+
+Expected output: the file exists. The README.md in the `main-repo` fixture contains two lines:
+
+```
+# Test Repository
+# Development features
+```
+
+Line 1 was authored by `Test User <test@example.com>` in the initial commit (`a56aab9`). Line 2 was authored in commit `98a81b6` (`Add develop branch`). We reference these values in later tests.
+
+---
+
+## File Structure
+
+- **Create:** `src/git_blame.cpp` — all four table functions + shared blame core
+- **Modify:** `src/include/git_functions.hpp` — add `RegisterGitBlameFunction` declaration
+- **Modify:** `src/git_functions.cpp` — call `RegisterGitBlameFunction(loader)` in `RegisterGitFunctions`
+- **Modify:** `CMakeLists.txt` — append `src/git_blame.cpp` to `EXTENSION_SOURCES`
+- **Create:** `test/sql/git_blame.test` — logic tests
+- **Create:** `docs/reference/git_blame.md` — user-facing reference docs
+
+---
+
+## Task 1: Scaffold `git_blame.cpp` and wire registration
+
+**Files:**
+- Create: `src/git_blame.cpp`
+- Modify: `src/include/git_functions.hpp` (add declaration, end of file before `RegisterGitFunctions`)
+- Modify: `src/git_functions.cpp` (two edits: forward declare + call in `RegisterGitFunctions`)
+- Modify: `CMakeLists.txt:18`
+
+Goal: get an empty `RegisterGitBlameFunction` that the extension calls at load time, so the build succeeds before we add any functions.
+
+- [ ] **Step 1: Create the empty source file**
+
+Write `src/git_blame.cpp`:
+
+```cpp
+#include "duckdb.hpp"
+#include "git_functions.hpp"
+#include "git_filesystem.hpp"
+#include "git_path.hpp"
+#include "git_context_manager.hpp"
+#include "git_utils.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/common/exception.hpp"
+
+#include <git2.h>
+
+namespace duckdb {
+
+void RegisterGitBlameFunction(ExtensionLoader &loader) {
+	// Functions will be registered in later tasks.
+	(void)loader;
+}
+
+} // namespace duckdb
+```
+
+- [ ] **Step 2: Declare the registration function in the header**
+
+Edit `src/include/git_functions.hpp`. Find the block of `Register*` declarations near the end (around line 327-336) and add one line:
+
+```cpp
+void RegisterGitDiffTreeFunction(ExtensionLoader &loader);
+void RegisterGitBlameFunction(ExtensionLoader &loader);
+void RegisterGitFunctions(ExtensionLoader &loader);
+```
+
+- [ ] **Step 3: Register the function in `git_functions.cpp`**
+
+Edit `src/git_functions.cpp`. Two edits:
+
+1. Forward declare near the other `void Register*` forward declarations (around line 31):
+
+```cpp
+void RegisterGitDiffTreeFunction(ExtensionLoader &loader);
+void RegisterGitBlameFunction(ExtensionLoader &loader);
+```
+
+2. Call it inside `RegisterGitFunctions` (around line 42):
+
+```cpp
+	RegisterGitDiffTreeFunction(loader);
+	RegisterGitBlameFunction(loader);
+}
+```
+
+- [ ] **Step 4: Add the source file to CMakeLists.txt**
+
+Edit `CMakeLists.txt` line 18. Append `src/git_blame.cpp` to the end of the `EXTENSION_SOURCES` list:
+
+```cmake
+set(EXTENSION_SOURCES src/duck_tails_extension.cpp src/git_filesystem.cpp src/git_functions.cpp src/git_log.cpp src/git_path.cpp src/git_utils.cpp src/git_context_manager.cpp src/git_tree.cpp src/git_parents.cpp src/git_branches.cpp src/git_tags.cpp src/git_read.cpp src/git_uri.cpp src/text_diff.cpp src/git_history.cpp src/git_status.cpp src/git_diff_tree.cpp src/git_blame.cpp)
+```
+
+- [ ] **Step 5: Build to verify scaffolding compiles**
+
+Run:
+
+```bash
+make debug -j
+```
+
+Expected: build succeeds. There are no new SQL functions yet — that's intentional.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/git_blame.cpp src/include/git_functions.hpp src/git_functions.cpp CMakeLists.txt
+git commit -m "Scaffold git_blame.cpp and wire registration (issue #18)"
+```
+
+---
+
+## Task 2: `git_blame_hunks` single-file static form
+
+**Files:**
+- Modify: `src/git_blame.cpp`
+- Create: `test/sql/git_blame.test`
+
+Goal: the simplest possible working function. Takes one positional path argument, no URI support, no named params, always HEAD, returns one row per libgit2 blame hunk. This gives us the `CollectBlameRows` core and the row-output machinery; later tasks add features.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/sql/git_blame.test`:
+
+```
+# name: test/sql/git_blame.test
+# description: Tests for git_blame and git_blame_hunks table functions (issue #18)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+statement ok
+PRAGMA enable_verification;
+
+# git_blame_hunks: basic single-positional form. The main-repo fixture's
+# README.md has 2 lines from 2 different commits, so we expect 2 hunks.
+query I
+SELECT COUNT(*) FROM git_blame_hunks('test/tmp/main-repo/README.md')
+----
+2
+
+# Hunk line counts must sum to the file's line count (2)
+query I
+SELECT SUM(line_count) FROM git_blame_hunks('test/tmp/main-repo/README.md')
+----
+2
+
+# First hunk covers line 1 and the author matches the fixture
+query III
+SELECT start_line, line_count, author_name
+FROM git_blame_hunks('test/tmp/main-repo/README.md')
+ORDER BY start_line
+----
+1	1	Test User
+2	1	Test User
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: FAIL — `git_blame_hunks` does not exist.
+
+- [ ] **Step 3: Add the shared blame row struct and core helper**
+
+Edit `src/git_blame.cpp`. Replace the body of the `namespace duckdb { ... }` block with the following. This adds the row struct, an options struct, a helper to turn a libgit2 signature into a DuckDB timestamp + strings, and the `CollectBlameRows` core that both output shapes will share.
+
+```cpp
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Helpers
+//===--------------------------------------------------------------------===//
+
+static string ExtractFileExtension(const string &path) {
+	size_t dot_pos = path.find_last_of('.');
+	if (dot_pos == string::npos || dot_pos == path.length() - 1) {
+		return "";
+	}
+	return path.substr(dot_pos);
+}
+
+static string OidToHex(const git_oid *oid) {
+	char hex[GIT_OID_HEXSZ + 1];
+	git_oid_tostr(hex, sizeof(hex), oid);
+	return string(hex);
+}
+
+//===--------------------------------------------------------------------===//
+// GitBlameRow — covers both per-line and per-hunk output shapes.
+//===--------------------------------------------------------------------===//
+
+struct GitBlameRow {
+	// Identity (populated by caller, not CollectBlameRows)
+	string repo_path;
+	string file_path;
+	string file_ext;
+	string revision;
+
+	// Per-line fields (git_blame)
+	int64_t line_number = 0;
+	string line_content;
+	bool line_content_is_null = false;
+
+	// Per-hunk fields (git_blame_hunks)
+	int64_t start_line = 0;
+	int64_t line_count = 0;
+	int64_t orig_start_line = 0;
+
+	// Shared fields
+	string commit_hash;
+	string author_name;
+	string author_email;
+	timestamp_t author_date = timestamp_t(0);
+	string orig_commit_hash;
+	string orig_path;
+	int64_t orig_line_number = 0;
+	bool boundary = false;
+};
+
+//===--------------------------------------------------------------------===//
+// GitBlameOptions — mirror of the blame-related named parameters.
+//===--------------------------------------------------------------------===//
+
+struct GitBlameOptions {
+	int64_t min_line = 0; // 0 means "no lower bound"
+	int64_t max_line = 0; // 0 means "no upper bound"
+	bool ignore_whitespace = false;
+	bool use_mailmap = false;
+	bool first_parent = false;
+};
+
+//===--------------------------------------------------------------------===//
+// Blame core
+//===--------------------------------------------------------------------===//
+
+// Loads the blob for `file_path` at `commit` and splits it into lines
+// (strips trailing `\r`). Returns false if the blob is binary; `lines` is
+// left empty in that case.
+static bool LoadFileLines(git_repository *repo, git_commit *commit, const string &file_path, vector<string> &lines) {
+	git_tree *tree = nullptr;
+	int error = git_commit_tree(&tree, commit);
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw IOException("git_blame: failed to get commit tree: %s", e ? e->message : "unknown error");
+	}
+
+	git_tree_entry *entry = nullptr;
+	error = git_tree_entry_bypath(&entry, tree, file_path.c_str());
+	if (error != 0) {
+		git_tree_free(tree);
+		throw IOException("git_blame: file not found '%s' at revision", file_path);
+	}
+
+	git_blob *blob = nullptr;
+	error = git_blob_lookup(&blob, repo, git_tree_entry_id(entry));
+	if (error != 0) {
+		git_tree_entry_free(entry);
+		git_tree_free(tree);
+		throw IOException("git_blame: failed to load blob for '%s'", file_path);
+	}
+
+	bool is_binary = git_blob_is_binary(blob) != 0;
+	if (!is_binary) {
+		const char *data = static_cast<const char *>(git_blob_rawcontent(blob));
+		size_t size = static_cast<size_t>(git_blob_rawsize(blob));
+		size_t start = 0;
+		for (size_t i = 0; i < size; i++) {
+			if (data[i] == '\n') {
+				size_t end = i;
+				if (end > start && data[end - 1] == '\r') {
+					end--;
+				}
+				lines.emplace_back(data + start, end - start);
+				start = i + 1;
+			}
+		}
+		if (start < size) {
+			size_t end = size;
+			if (end > start && data[end - 1] == '\r') {
+				end--;
+			}
+			lines.emplace_back(data + start, end - start);
+		}
+	}
+
+	git_blob_free(blob);
+	git_tree_entry_free(entry);
+	git_tree_free(tree);
+	return !is_binary;
+}
+
+// Computes blame rows for (repo, file_path) at `revision`. If `per_line` is
+// true, emits one row per line with `line_content`; otherwise emits one row
+// per hunk with `start_line`/`line_count`.
+static void CollectBlameRows(git_repository *repo, const string &repo_path, const string &file_path,
+                             const string &revision, const GitBlameOptions &opts, bool per_line,
+                             vector<GitBlameRow> &rows) {
+	git_object *rev_obj = nullptr;
+	int error = git_revparse_single(&rev_obj, repo, revision.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw IOException("git_blame: unable to resolve revision '%s': %s", revision, e ? e->message : "unknown error");
+	}
+
+	git_commit *commit = nullptr;
+	error = git_object_peel(reinterpret_cast<git_object **>(&commit), rev_obj, GIT_OBJECT_COMMIT);
+	if (error != 0) {
+		git_object_free(rev_obj);
+		throw IOException("git_blame: revision '%s' does not resolve to a commit", revision);
+	}
+
+	// Build blame options.
+	git_blame_options blame_opts = GIT_BLAME_OPTIONS_INIT;
+	git_oid_cpy(&blame_opts.newest_commit, git_commit_id(commit));
+	if (opts.min_line > 0) {
+		blame_opts.min_line = static_cast<size_t>(opts.min_line);
+	}
+	if (opts.max_line > 0) {
+		blame_opts.max_line = static_cast<size_t>(opts.max_line);
+	}
+	uint32_t flags = 0;
+	if (opts.ignore_whitespace) {
+		flags |= GIT_BLAME_IGNORE_WHITESPACE;
+	}
+	if (opts.use_mailmap) {
+		flags |= GIT_BLAME_USE_MAILMAP;
+	}
+	if (opts.first_parent) {
+		flags |= GIT_BLAME_FIRST_PARENT;
+	}
+	blame_opts.flags = flags;
+
+	git_blame *blame = nullptr;
+	error = git_blame_file(&blame, repo, file_path.c_str(), &blame_opts);
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		git_commit_free(commit);
+		git_object_free(rev_obj);
+		throw IOException("git_blame: blame failed for '%s': %s", file_path, e ? e->message : "unknown error");
+	}
+
+	// Load file lines if we need line_content.
+	vector<string> file_lines;
+	bool have_text = false;
+	if (per_line) {
+		try {
+			have_text = LoadFileLines(repo, commit, file_path, file_lines);
+		} catch (...) {
+			git_blame_free(blame);
+			git_commit_free(commit);
+			git_object_free(rev_obj);
+			throw;
+		}
+	}
+
+	string file_ext = ExtractFileExtension(file_path);
+	uint32_t hunk_count = git_blame_get_hunk_count(blame);
+	for (uint32_t i = 0; i < hunk_count; i++) {
+		const git_blame_hunk *hunk = git_blame_get_hunk_byindex(blame, i);
+		if (!hunk) {
+			continue;
+		}
+
+		string commit_hash = OidToHex(&hunk->final_commit_id);
+		string orig_commit_hash = OidToHex(&hunk->orig_commit_id);
+		string author_name = hunk->final_signature && hunk->final_signature->name ? hunk->final_signature->name : "";
+		string author_email =
+		    hunk->final_signature && hunk->final_signature->email ? hunk->final_signature->email : "";
+		timestamp_t author_date = timestamp_t(0);
+		if (hunk->final_signature) {
+			// libgit2 git_time is seconds since epoch (UTC).
+			author_date = Timestamp::FromEpochSeconds(hunk->final_signature->when.time);
+		}
+		string orig_path = hunk->orig_path ? string(hunk->orig_path) : file_path;
+		bool boundary = hunk->boundary != 0;
+
+		if (per_line) {
+			for (size_t offset = 0; offset < hunk->lines_in_hunk; offset++) {
+				int64_t line_no = static_cast<int64_t>(hunk->final_start_line_number + offset);
+				GitBlameRow row;
+				row.repo_path = repo_path;
+				row.file_path = file_path;
+				row.file_ext = file_ext;
+				row.revision = revision;
+				row.line_number = line_no;
+				if (have_text && line_no >= 1 && static_cast<size_t>(line_no) <= file_lines.size()) {
+					row.line_content = file_lines[line_no - 1];
+					row.line_content_is_null = false;
+				} else {
+					row.line_content_is_null = true;
+				}
+				row.commit_hash = commit_hash;
+				row.author_name = author_name;
+				row.author_email = author_email;
+				row.author_date = author_date;
+				row.orig_commit_hash = orig_commit_hash;
+				row.orig_path = orig_path;
+				row.orig_line_number = static_cast<int64_t>(hunk->orig_start_line_number + offset);
+				row.boundary = boundary;
+				rows.push_back(std::move(row));
+			}
+		} else {
+			GitBlameRow row;
+			row.repo_path = repo_path;
+			row.file_path = file_path;
+			row.file_ext = file_ext;
+			row.revision = revision;
+			row.start_line = static_cast<int64_t>(hunk->final_start_line_number);
+			row.line_count = static_cast<int64_t>(hunk->lines_in_hunk);
+			row.orig_start_line = static_cast<int64_t>(hunk->orig_start_line_number);
+			row.commit_hash = commit_hash;
+			row.author_name = author_name;
+			row.author_email = author_email;
+			row.author_date = author_date;
+			row.orig_commit_hash = orig_commit_hash;
+			row.orig_path = orig_path;
+			row.boundary = boundary;
+			rows.push_back(std::move(row));
+		}
+	}
+
+	git_blame_free(blame);
+	git_commit_free(commit);
+	git_object_free(rev_obj);
+}
+
+//===--------------------------------------------------------------------===//
+// Schemas
+//===--------------------------------------------------------------------===//
+
+static void DefineHunksSchema(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types = {LogicalType::VARCHAR,   LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::BIGINT,    LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::VARCHAR,   LogicalType::TIMESTAMP, LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::BOOLEAN};
+	names = {"repo_path",        "file_path",   "file_ext",         "revision",     "start_line",
+	         "line_count",       "commit_hash", "author_name",      "author_email", "author_date",
+	         "orig_commit_hash", "orig_path",   "orig_start_line",  "boundary"};
+}
+
+static void OutputHunkRow(DataChunk &output, const GitBlameRow &row, idx_t row_idx) {
+	output.SetValue(0, row_idx, Value(row.repo_path));
+	output.SetValue(1, row_idx, Value(row.file_path));
+	output.SetValue(2, row_idx, Value(row.file_ext));
+	output.SetValue(3, row_idx, Value(row.revision));
+	output.SetValue(4, row_idx, Value::BIGINT(row.start_line));
+	output.SetValue(5, row_idx, Value::BIGINT(row.line_count));
+	output.SetValue(6, row_idx, Value(row.commit_hash));
+	output.SetValue(7, row_idx, Value(row.author_name));
+	output.SetValue(8, row_idx, Value(row.author_email));
+	output.SetValue(9, row_idx, Value::TIMESTAMP(row.author_date));
+	output.SetValue(10, row_idx, Value(row.orig_commit_hash));
+	output.SetValue(11, row_idx, Value(row.orig_path));
+	output.SetValue(12, row_idx, Value::BIGINT(row.orig_start_line));
+	output.SetValue(13, row_idx, Value::BOOLEAN(row.boundary));
+}
+
+//===--------------------------------------------------------------------===//
+// Bind data — single struct used for all four functions.
+//===--------------------------------------------------------------------===//
+
+struct GitBlameBindData : public TableFunctionData {
+	string repo_path;
+	string file_path;
+	string revision;
+	GitBlameOptions opts;
+	bool per_line = true;  // false for *_hunks variants
+	bool is_lateral = false;
+	vector<GitBlameRow> rows; // Materialized at bind time for static forms
+};
+
+struct GitBlameLocalState : public LocalTableFunctionState {
+	idx_t current_index = 0;
+
+	// LATERAL processing state (unused in static form)
+	vector<GitBlameRow> current_rows;
+	idx_t current_input_row = 0;
+	idx_t current_output_row = 0;
+	bool initialized_row = false;
+};
+
+//===--------------------------------------------------------------------===//
+// git_blame_hunks static bind + exec
+//===--------------------------------------------------------------------===//
+
+static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	DefineHunksSchema(return_types, names);
+
+	if (input.inputs.empty()) {
+		throw BinderException("git_blame_hunks requires a file path as its first argument");
+	}
+
+	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+	if (params.resolved_file_path.empty()) {
+		throw BinderException("git_blame_hunks: '%s' must refer to a file inside a git repository",
+		                      params.repo_path_or_uri);
+	}
+
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->repo_path = params.resolved_repo_path;
+	bind_data->file_path = params.resolved_file_path;
+	bind_data->revision = params.ref;
+	bind_data->per_line = false;
+
+	git_repository *repo = nullptr;
+	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw BinderException("git_blame_hunks: failed to open repository '%s': %s", bind_data->repo_path,
+		                      e ? e->message : "unknown error");
+	}
+
+	try {
+		CollectBlameRows(repo, bind_data->repo_path, bind_data->file_path, bind_data->revision, bind_data->opts,
+		                 /*per_line=*/false, bind_data->rows);
+	} catch (...) {
+		git_repository_free(repo);
+		throw;
+	}
+	git_repository_free(repo);
+
+	return std::move(bind_data);
+}
+
+static unique_ptr<GlobalTableFunctionState> GitBlameInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<GlobalTableFunctionState>();
+}
+
+static unique_ptr<LocalTableFunctionState>
+GitBlameLocalInit(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
+	return make_uniq<GitBlameLocalState>();
+}
+
+static void GitBlameHunksFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<GitBlameBindData>();
+	auto &local_state = data_p.local_state->Cast<GitBlameLocalState>();
+
+	idx_t output_count = 0;
+	while (local_state.current_index < bind_data.rows.size() && output_count < STANDARD_VECTOR_SIZE) {
+		OutputHunkRow(output, bind_data.rows[local_state.current_index], output_count);
+		local_state.current_index++;
+		output_count++;
+	}
+	output.SetCardinality(output_count);
+}
+
+//===--------------------------------------------------------------------===//
+// Registration
+//===--------------------------------------------------------------------===//
+
+void RegisterGitBlameFunction(ExtensionLoader &loader) {
+	TableFunctionSet git_blame_hunks_set("git_blame_hunks");
+	TableFunction hunks_one({LogicalType::VARCHAR}, GitBlameHunksFunction, GitBlameHunksBind, GitBlameInitGlobal);
+	hunks_one.init_local = GitBlameLocalInit;
+	git_blame_hunks_set.AddFunction(hunks_one);
+	loader.RegisterFunction(git_blame_hunks_set);
+}
+
+} // namespace duckdb
+```
+
+Note: we pass `ref_param_index=999` to `ParseUnifiedGitParams` to effectively disable its positional-ref lookup. The revision will come from `params.ref` which defaults to `HEAD` (and will be driven by the named `revision` parameter in Task 5).
+
+- [ ] **Step 4: Build**
+
+Run:
+
+```bash
+make debug -j
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Run the test and verify it passes**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS. All three queries in `git_blame.test` return expected values.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/git_blame.cpp test/sql/git_blame.test
+git commit -m "Add git_blame_hunks single-positional form (issue #18)"
+```
+
+---
+
+## Task 3: `git_blame` per-line static form
+
+**Files:**
+- Modify: `src/git_blame.cpp` (add schema + output + bind + exec + registration)
+- Modify: `test/sql/git_blame.test` (add per-line tests)
+
+Goal: add the primary per-line form. Same single-positional signature as `git_blame_hunks`, but output is one row per line with `line_content`.
+
+- [ ] **Step 1: Add per-line tests that fail**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# git_blame per-line form
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md')
+----
+2
+
+# Line numbers and content for each row
+query III
+SELECT line_number, line_content, author_name
+FROM git_blame('test/tmp/main-repo/README.md')
+ORDER BY line_number
+----
+1	# Test Repository	Test User
+2	# Development features	Test User
+
+# line_number starts at 1
+query I
+SELECT MIN(line_number) FROM git_blame('test/tmp/main-repo/README.md')
+----
+1
+
+# commit_hash should be non-null for every row
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md') WHERE commit_hash IS NULL
+----
+0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: FAIL — `git_blame` does not exist.
+
+- [ ] **Step 3: Add the per-line schema, output, bind, exec**
+
+Edit `src/git_blame.cpp`. Add the following **above** `RegisterGitBlameFunction` (between the hunks exec function and the registration function):
+
+```cpp
+//===--------------------------------------------------------------------===//
+// git_blame per-line schema + exec
+//===--------------------------------------------------------------------===//
+
+static void DefineBlameSchema(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types = {LogicalType::VARCHAR,   LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::VARCHAR,   LogicalType::TIMESTAMP, LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::BOOLEAN};
+	names = {"repo_path",        "file_path",   "file_ext",         "revision",     "line_number",
+	         "line_content",     "commit_hash", "author_name",      "author_email", "author_date",
+	         "orig_commit_hash", "orig_path",   "orig_line_number", "boundary"};
+}
+
+static void OutputBlameRow(DataChunk &output, const GitBlameRow &row, idx_t row_idx) {
+	output.SetValue(0, row_idx, Value(row.repo_path));
+	output.SetValue(1, row_idx, Value(row.file_path));
+	output.SetValue(2, row_idx, Value(row.file_ext));
+	output.SetValue(3, row_idx, Value(row.revision));
+	output.SetValue(4, row_idx, Value::BIGINT(row.line_number));
+	if (row.line_content_is_null) {
+		output.SetValue(5, row_idx, Value());
+	} else {
+		output.SetValue(5, row_idx, Value(row.line_content));
+	}
+	output.SetValue(6, row_idx, Value(row.commit_hash));
+	output.SetValue(7, row_idx, Value(row.author_name));
+	output.SetValue(8, row_idx, Value(row.author_email));
+	output.SetValue(9, row_idx, Value::TIMESTAMP(row.author_date));
+	output.SetValue(10, row_idx, Value(row.orig_commit_hash));
+	output.SetValue(11, row_idx, Value(row.orig_path));
+	output.SetValue(12, row_idx, Value::BIGINT(row.orig_line_number));
+	output.SetValue(13, row_idx, Value::BOOLEAN(row.boundary));
+}
+
+static unique_ptr<FunctionData> GitBlameBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	DefineBlameSchema(return_types, names);
+
+	if (input.inputs.empty()) {
+		throw BinderException("git_blame requires a file path as its first argument");
+	}
+
+	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+	if (params.resolved_file_path.empty()) {
+		throw BinderException("git_blame: '%s' must refer to a file inside a git repository",
+		                      params.repo_path_or_uri);
+	}
+
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->repo_path = params.resolved_repo_path;
+	bind_data->file_path = params.resolved_file_path;
+	bind_data->revision = params.ref;
+	bind_data->per_line = true;
+
+	git_repository *repo = nullptr;
+	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw BinderException("git_blame: failed to open repository '%s': %s", bind_data->repo_path,
+		                      e ? e->message : "unknown error");
+	}
+	try {
+		CollectBlameRows(repo, bind_data->repo_path, bind_data->file_path, bind_data->revision, bind_data->opts,
+		                 /*per_line=*/true, bind_data->rows);
+	} catch (...) {
+		git_repository_free(repo);
+		throw;
+	}
+	git_repository_free(repo);
+
+	return std::move(bind_data);
+}
+
+static void GitBlameFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<GitBlameBindData>();
+	auto &local_state = data_p.local_state->Cast<GitBlameLocalState>();
+
+	idx_t output_count = 0;
+	while (local_state.current_index < bind_data.rows.size() && output_count < STANDARD_VECTOR_SIZE) {
+		OutputBlameRow(output, bind_data.rows[local_state.current_index], output_count);
+		local_state.current_index++;
+		output_count++;
+	}
+	output.SetCardinality(output_count);
+}
+```
+
+- [ ] **Step 4: Register the new function**
+
+Edit `RegisterGitBlameFunction` in the same file. Replace its body with:
+
+```cpp
+void RegisterGitBlameFunction(ExtensionLoader &loader) {
+	TableFunctionSet git_blame_hunks_set("git_blame_hunks");
+	TableFunction hunks_one({LogicalType::VARCHAR}, GitBlameHunksFunction, GitBlameHunksBind, GitBlameInitGlobal);
+	hunks_one.init_local = GitBlameLocalInit;
+	git_blame_hunks_set.AddFunction(hunks_one);
+	loader.RegisterFunction(git_blame_hunks_set);
+
+	TableFunctionSet git_blame_set("git_blame");
+	TableFunction blame_one({LogicalType::VARCHAR}, GitBlameFunction, GitBlameBind, GitBlameInitGlobal);
+	blame_one.init_local = GitBlameLocalInit;
+	git_blame_set.AddFunction(blame_one);
+	loader.RegisterFunction(git_blame_set);
+}
+```
+
+- [ ] **Step 5: Build and run the tests**
+
+Run:
+
+```bash
+make debug -j && make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: all tests pass (the three hunks tests from Task 2 plus the four new per-line tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/git_blame.cpp test/sql/git_blame.test
+git commit -m "Add git_blame per-line static form (issue #18)"
+```
+
+---
+
+## Task 4: Support `git://` URI input
+
+**Files:**
+- Modify: `test/sql/git_blame.test` (add URI-form test)
+
+Goal: verify the URI form works end-to-end. `ParseUnifiedGitParams` already handles `git://` URIs — this task just asserts the behavior with a test. If the test fails, we need to debug `ParseUnifiedGitParams`'s interaction with our bind data; if it passes, the URI path is free.
+
+- [ ] **Step 1: Add URI-form test**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# git:// URI form should produce the same result as the plain path form
+query II
+SELECT line_number, author_name
+FROM git_blame('git://test/tmp/main-repo/README.md@HEAD')
+ORDER BY line_number
+----
+1	Test User
+2	Test User
+
+# git_blame_hunks URI form
+query I
+SELECT COUNT(*) FROM git_blame_hunks('git://test/tmp/main-repo/README.md@HEAD')
+----
+2
+```
+
+- [ ] **Step 2: Run the test**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS. `ParseUnifiedGitParams` already handles `git://` URIs and produces `resolved_repo_path` + `resolved_file_path` + `ref` for us.
+
+If the test fails: inspect the error. The most likely culprit is that `ParseUnifiedGitParams` leaves `resolved_file_path` empty or that the ref isn't being picked up from the URI. In that case, add logging in the binder to print `params.resolved_repo_path`, `params.resolved_file_path`, and `params.ref` — and then fix accordingly. (Do not silently paper over a failure here; URI support is spec-critical.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/sql/git_blame.test
+git commit -m "Test git_blame with git:// URI form (issue #18)"
+```
+
+---
+
+## Task 5: Named parameters `revision` and `repo_path`
+
+**Files:**
+- Modify: `src/git_blame.cpp` (both binders + registration)
+- Modify: `test/sql/git_blame.test`
+
+Goal: add `revision := ...` and `repo_path := ...` named parameters. These are the two identity-level options that every static call might need. `revision` overrides the default `HEAD`; `repo_path` lets the first positional be just a file path within the repo.
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# Explicit revision via named parameter
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md', revision := 'HEAD')
+----
+2
+
+# Explicit repo_path with file_path relative to it
+query II
+SELECT line_number, author_name
+FROM git_blame('README.md', repo_path := 'test/tmp/main-repo')
+ORDER BY line_number
+----
+1	Test User
+2	Test User
+
+# Both named params together
+query I
+SELECT COUNT(*)
+FROM git_blame_hunks('README.md', repo_path := 'test/tmp/main-repo', revision := 'HEAD')
+----
+2
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: FAIL — `revision` and `repo_path` are not declared named parameters on the function.
+
+- [ ] **Step 3: Add a helper to parse named parameters into `GitBlameBindData`**
+
+Edit `src/git_blame.cpp`. Add the following helper **above** `GitBlameHunksBind`:
+
+```cpp
+// Extract the named parameters shared by every git_blame* static form.
+// Mutates `bind_data` and returns the overridden repo_path/revision for the
+// caller to apply *after* initial positional parsing.
+static void ApplyBlameNamedParams(const TableFunctionBindInput &input, GitBlameBindData &bind_data,
+                                  string &override_repo_path, string &override_revision) {
+	for (const auto &kv : input.named_parameters) {
+		if (kv.first == "repo_path") {
+			override_repo_path = kv.second.GetValue<string>();
+		} else if (kv.first == "revision") {
+			override_revision = kv.second.GetValue<string>();
+		} else if (kv.first == "min_line") {
+			bind_data.opts.min_line = kv.second.GetValue<int64_t>();
+		} else if (kv.first == "max_line") {
+			bind_data.opts.max_line = kv.second.GetValue<int64_t>();
+		} else if (kv.first == "ignore_whitespace") {
+			bind_data.opts.ignore_whitespace = kv.second.GetValue<bool>();
+		} else if (kv.first == "use_mailmap") {
+			bind_data.opts.use_mailmap = kv.second.GetValue<bool>();
+		} else if (kv.first == "first_parent") {
+			bind_data.opts.first_parent = kv.second.GetValue<bool>();
+		}
+	}
+}
+```
+
+(We already wire `min_line`/`max_line` and the flags here so Tasks 6 and 7 only have to add validation + tests — the parsing is in place.)
+
+- [ ] **Step 4: Use the helper in both binders, and handle `repo_path` override**
+
+Edit `GitBlameHunksBind`. Replace its body with:
+
+```cpp
+static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	DefineHunksSchema(return_types, names);
+
+	if (input.inputs.empty()) {
+		throw BinderException("git_blame_hunks requires a file path as its first argument");
+	}
+
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->per_line = false;
+
+	string override_repo_path;
+	string override_revision;
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+
+	string first_param = input.inputs[0].GetValue<string>();
+	string resolved_repo_path;
+	string resolved_file_path;
+	string resolved_revision;
+
+	if (!override_repo_path.empty()) {
+		// User provided repo_path explicitly; first positional is the file path within it.
+		string uri = "git://" + override_repo_path + "/" + first_param + "@HEAD";
+		auto ctx = GitContextManager::Instance().ProcessGitUri(uri, "HEAD");
+		resolved_repo_path = ctx.repo_path;
+		resolved_file_path = ctx.file_path;
+		resolved_revision = "HEAD";
+	} else {
+		auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+		if (params.resolved_file_path.empty()) {
+			throw BinderException("git_blame_hunks: '%s' must refer to a file inside a git repository",
+			                      params.repo_path_or_uri);
+		}
+		resolved_repo_path = params.resolved_repo_path;
+		resolved_file_path = params.resolved_file_path;
+		resolved_revision = params.ref;
+	}
+
+	if (!override_revision.empty()) {
+		resolved_revision = override_revision;
+	}
+
+	bind_data->repo_path = resolved_repo_path;
+	bind_data->file_path = resolved_file_path;
+	bind_data->revision = resolved_revision;
+
+	git_repository *repo = nullptr;
+	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw BinderException("git_blame_hunks: failed to open repository '%s': %s", bind_data->repo_path,
+		                      e ? e->message : "unknown error");
+	}
+	try {
+		CollectBlameRows(repo, bind_data->repo_path, bind_data->file_path, bind_data->revision, bind_data->opts,
+		                 /*per_line=*/false, bind_data->rows);
+	} catch (...) {
+		git_repository_free(repo);
+		throw;
+	}
+	git_repository_free(repo);
+
+	return std::move(bind_data);
+}
+```
+
+Replace `GitBlameBind` with the parallel per-line version:
+
+```cpp
+static unique_ptr<FunctionData> GitBlameBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	DefineBlameSchema(return_types, names);
+
+	if (input.inputs.empty()) {
+		throw BinderException("git_blame requires a file path as its first argument");
+	}
+
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->per_line = true;
+
+	string override_repo_path;
+	string override_revision;
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+
+	string first_param = input.inputs[0].GetValue<string>();
+	string resolved_repo_path;
+	string resolved_file_path;
+	string resolved_revision;
+
+	if (!override_repo_path.empty()) {
+		string uri = "git://" + override_repo_path + "/" + first_param + "@HEAD";
+		auto ctx = GitContextManager::Instance().ProcessGitUri(uri, "HEAD");
+		resolved_repo_path = ctx.repo_path;
+		resolved_file_path = ctx.file_path;
+		resolved_revision = "HEAD";
+	} else {
+		auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+		if (params.resolved_file_path.empty()) {
+			throw BinderException("git_blame: '%s' must refer to a file inside a git repository",
+			                      params.repo_path_or_uri);
+		}
+		resolved_repo_path = params.resolved_repo_path;
+		resolved_file_path = params.resolved_file_path;
+		resolved_revision = params.ref;
+	}
+
+	if (!override_revision.empty()) {
+		resolved_revision = override_revision;
+	}
+
+	bind_data->repo_path = resolved_repo_path;
+	bind_data->file_path = resolved_file_path;
+	bind_data->revision = resolved_revision;
+
+	git_repository *repo = nullptr;
+	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw BinderException("git_blame: failed to open repository '%s': %s", bind_data->repo_path,
+		                      e ? e->message : "unknown error");
+	}
+	try {
+		CollectBlameRows(repo, bind_data->repo_path, bind_data->file_path, bind_data->revision, bind_data->opts,
+		                 /*per_line=*/true, bind_data->rows);
+	} catch (...) {
+		git_repository_free(repo);
+		throw;
+	}
+	git_repository_free(repo);
+
+	return std::move(bind_data);
+}
+```
+
+- [ ] **Step 5: Declare named parameters on the registered functions**
+
+Edit `RegisterGitBlameFunction` so each function set declares the named parameters:
+
+```cpp
+void RegisterGitBlameFunction(ExtensionLoader &loader) {
+	auto declare_named_params = [](TableFunction &fn) {
+		fn.named_parameters["repo_path"] = LogicalType::VARCHAR;
+		fn.named_parameters["revision"] = LogicalType::VARCHAR;
+		fn.named_parameters["min_line"] = LogicalType::BIGINT;
+		fn.named_parameters["max_line"] = LogicalType::BIGINT;
+		fn.named_parameters["ignore_whitespace"] = LogicalType::BOOLEAN;
+		fn.named_parameters["use_mailmap"] = LogicalType::BOOLEAN;
+		fn.named_parameters["first_parent"] = LogicalType::BOOLEAN;
+	};
+
+	TableFunctionSet git_blame_hunks_set("git_blame_hunks");
+	TableFunction hunks_one({LogicalType::VARCHAR}, GitBlameHunksFunction, GitBlameHunksBind, GitBlameInitGlobal);
+	hunks_one.init_local = GitBlameLocalInit;
+	declare_named_params(hunks_one);
+	git_blame_hunks_set.AddFunction(hunks_one);
+	loader.RegisterFunction(git_blame_hunks_set);
+
+	TableFunctionSet git_blame_set("git_blame");
+	TableFunction blame_one({LogicalType::VARCHAR}, GitBlameFunction, GitBlameBind, GitBlameInitGlobal);
+	blame_one.init_local = GitBlameLocalInit;
+	declare_named_params(blame_one);
+	git_blame_set.AddFunction(blame_one);
+	loader.RegisterFunction(git_blame_set);
+}
+```
+
+- [ ] **Step 6: Build and run**
+
+Run:
+
+```bash
+make debug -j && make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS (including the three new named-param tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/git_blame.cpp test/sql/git_blame.test
+git commit -m "Add repo_path and revision named parameters to git_blame (issue #18)"
+```
+
+---
+
+## Task 6: `min_line` / `max_line` named parameters
+
+**Files:**
+- Modify: `src/git_blame.cpp` (add validation)
+- Modify: `test/sql/git_blame.test`
+
+Goal: add `min_line` / `max_line` with bound checking. The parsing is already wired by `ApplyBlameNamedParams` (Task 5) and the core already passes them into `git_blame_options` — this task just adds the user-facing validation and tests.
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# min_line restricts to the first line only
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md', min_line := 1, max_line := 1)
+----
+1
+
+query II
+SELECT line_number, line_content FROM git_blame('test/tmp/main-repo/README.md', min_line := 1, max_line := 1)
+----
+1	# Test Repository
+
+# max_line alone restricts to line <= 2 (all rows)
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md', max_line := 2)
+----
+2
+
+# min_line alone starts blame at line 2
+query II
+SELECT line_number, line_content FROM git_blame('test/tmp/main-repo/README.md', min_line := 2)
+----
+2	# Development features
+
+# Invalid range: min_line > max_line
+statement error
+SELECT * FROM git_blame('test/tmp/main-repo/README.md', min_line := 5, max_line := 1)
+----
+
+# Invalid: min_line = 0 (must be >= 1)
+statement error
+SELECT * FROM git_blame('test/tmp/main-repo/README.md', min_line := 0)
+----
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: at least the error tests fail because no validation exists yet. The first few may pass already since the parsing is in place.
+
+- [ ] **Step 3: Add validation**
+
+In `src/git_blame.cpp`, add a helper **above** `ApplyBlameNamedParams`:
+
+```cpp
+// Raise if min_line/max_line are out of range. Internally, 0 means "unset"
+// (GIT_BLAME_OPTIONS_INIT defaults); the user-facing minimum is 1.
+static void ValidateBlameOptions(const GitBlameOptions &opts, const char *func_name) {
+	if (opts.min_line < 0) {
+		throw BinderException("%s: min_line must be >= 1", func_name);
+	}
+	if (opts.max_line < 0) {
+		throw BinderException("%s: max_line must be >= 1", func_name);
+	}
+	if (opts.min_line > 0 && opts.max_line > 0 && opts.min_line > opts.max_line) {
+		throw BinderException("%s: min_line (%lld) must be <= max_line (%lld)", func_name,
+		                      (long long)opts.min_line, (long long)opts.max_line);
+	}
+}
+```
+
+Rejecting explicit 0 is handled inline in `ApplyBlameNamedParams`. Replace the
+`min_line`/`max_line` branches of the existing loop so they reject 0 on read:
+
+```cpp
+		} else if (kv.first == "min_line") {
+			int64_t v = kv.second.GetValue<int64_t>();
+			if (v <= 0) {
+				throw BinderException("git_blame: min_line must be >= 1");
+			}
+			bind_data.opts.min_line = v;
+		} else if (kv.first == "max_line") {
+			int64_t v = kv.second.GetValue<int64_t>();
+			if (v <= 0) {
+				throw BinderException("git_blame: max_line must be >= 1");
+			}
+			bind_data.opts.max_line = v;
+```
+
+Finally call `ValidateBlameOptions(bind_data->opts, "git_blame")` in `GitBlameBind` and `ValidateBlameOptions(bind_data->opts, "git_blame_hunks")` in `GitBlameHunksBind`, right after `ApplyBlameNamedParams`.
+
+- [ ] **Step 4: Build and run**
+
+Run:
+
+```bash
+make debug -j && make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS (all min_line/max_line tests, including the two `statement error` cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/git_blame.cpp test/sql/git_blame.test
+git commit -m "Add min_line/max_line parameters with validation (issue #18)"
+```
+
+---
+
+## Task 7: Smoke-test `ignore_whitespace` / `use_mailmap` / `first_parent`
+
+**Files:**
+- Modify: `test/sql/git_blame.test`
+
+Goal: the parameters are already parsed and wired into `git_blame_options` (Task 5). We just need tests that assert the parameters are accepted and return results without error. We don't assert behavioral differences because the main-repo fixture doesn't have whitespace-divergent history or a mailmap file — these are libgit2-native flags whose correctness is the library's problem.
+
+- [ ] **Step 1: Add smoke tests**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# ignore_whitespace smoke test
+query I
+SELECT COUNT(*) >= 0 FROM git_blame('test/tmp/main-repo/README.md', ignore_whitespace := true)
+----
+true
+
+# use_mailmap smoke test
+query I
+SELECT COUNT(*) >= 0 FROM git_blame('test/tmp/main-repo/README.md', use_mailmap := true)
+----
+true
+
+# first_parent smoke test
+query I
+SELECT COUNT(*) >= 0 FROM git_blame('test/tmp/main-repo/README.md', first_parent := true)
+----
+true
+
+# All flags at once
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md',
+                                ignore_whitespace := true,
+                                use_mailmap := true,
+                                first_parent := true)
+----
+2
+```
+
+- [ ] **Step 2: Build and run**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS. No new build needed — parameters were already wired in Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/sql/git_blame.test
+git commit -m "Smoke-test git_blame flag parameters (issue #18)"
+```
+
+---
+
+## Task 8: `git_blame_hunks_each` LATERAL variant
+
+**Files:**
+- Modify: `src/git_blame.cpp`
+- Modify: `test/sql/git_blame.test`
+
+Goal: add the LATERAL-only `git_blame_hunks_each` function. Takes a file path/URI from the input chunk at runtime and optionally a revision as the second LATERAL column. Mirrors the `git_read_each` pattern.
+
+- [ ] **Step 1: Add the failing LATERAL test**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# git_blame_hunks_each via LATERAL over a values list
+query II
+SELECT v.f, COUNT(*) AS n_hunks
+FROM (VALUES ('test/tmp/main-repo/README.md')) AS v(f),
+     LATERAL git_blame_hunks_each(v.f) h
+GROUP BY v.f
+ORDER BY v.f
+----
+test/tmp/main-repo/README.md	2
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: FAIL — `git_blame_hunks_each` does not exist.
+
+- [ ] **Step 3: Add the LATERAL bind and exec**
+
+Add to `src/git_blame.cpp`, **above** `RegisterGitBlameFunction`:
+
+```cpp
+//===--------------------------------------------------------------------===//
+// LATERAL variants
+//===--------------------------------------------------------------------===//
+
+// Shared bind for LATERAL forms: stores bind-time named parameters in bind
+// data; the runtime file path/URI and optional revision come from the input
+// DataChunk per row.
+static unique_ptr<FunctionData> GitBlameLateralBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     bool per_line) {
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->per_line = per_line;
+	bind_data->is_lateral = true;
+	bind_data->revision = "HEAD";
+
+	string override_repo_path; // ignored for LATERAL (runtime provides path)
+	string override_revision;
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+	ValidateBlameOptions(bind_data->opts, per_line ? "git_blame_each" : "git_blame_hunks_each");
+
+	if (!override_revision.empty()) {
+		bind_data->revision = override_revision;
+	}
+	return std::move(bind_data);
+}
+
+static unique_ptr<FunctionData> GitBlameHunksEachBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	DefineHunksSchema(return_types, names);
+	return GitBlameLateralBind(context, input, /*per_line=*/false);
+}
+
+// Resolve a LATERAL input path (URI or plain path) + optional per-row revision
+// override into (repo_path, file_path, revision).
+static void ResolveLateralInput(const string &raw_input, const string &bind_revision, const string &row_revision,
+                                string &out_repo_path, string &out_file_path, string &out_revision) {
+	// If the input is a git:// URI, let GitContextManager parse it fully.
+	if (StringUtil::StartsWith(raw_input, "git://")) {
+		auto ctx = GitContextManager::Instance().ProcessGitUri(raw_input, "HEAD");
+		out_repo_path = ctx.repo_path;
+		out_file_path = ctx.file_path;
+		// URI @rev wins unless the caller passed an explicit row revision.
+		if (!row_revision.empty()) {
+			out_revision = row_revision;
+		} else if (!ctx.final_ref.empty() && ctx.final_ref != "HEAD") {
+			out_revision = ctx.final_ref;
+		} else {
+			out_revision = bind_revision;
+		}
+		return;
+	}
+
+	// Plain path — discover repo via GitContextManager.
+	auto ctx = GitContextManager::Instance().ProcessGitUri("git://" + raw_input + "@HEAD", "HEAD");
+	out_repo_path = ctx.repo_path;
+	out_file_path = ctx.file_path;
+	out_revision = row_revision.empty() ? bind_revision : row_revision;
+}
+
+static OperatorResultType GitBlameEachImpl(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+                                            DataChunk &output, bool per_line) {
+	auto &state = data_p.local_state->Cast<GitBlameLocalState>();
+	auto &bind_data = data_p.bind_data->Cast<GitBlameBindData>();
+
+	while (true) {
+		if (!state.initialized_row) {
+			if (state.current_input_row >= input.size()) {
+				state.current_input_row = 0;
+				state.initialized_row = false;
+				return OperatorResultType::NEED_MORE_INPUT;
+			}
+
+			input.Flatten();
+			if (input.ColumnCount() == 0 || FlatVector::IsNull(input.data[0], state.current_input_row)) {
+				state.current_input_row++;
+				continue;
+			}
+
+			auto file_vec = FlatVector::GetData<string_t>(input.data[0]);
+			string raw_input(file_vec[state.current_input_row].GetData(),
+			                 file_vec[state.current_input_row].GetSize());
+
+			string row_revision;
+			if (input.ColumnCount() > 1 && !FlatVector::IsNull(input.data[1], state.current_input_row)) {
+				auto rev_vec = FlatVector::GetData<string_t>(input.data[1]);
+				row_revision = string(rev_vec[state.current_input_row].GetData(),
+				                      rev_vec[state.current_input_row].GetSize());
+			}
+
+			string repo_path, file_path, revision;
+			try {
+				ResolveLateralInput(raw_input, bind_data.revision, row_revision, repo_path, file_path, revision);
+			} catch (...) {
+				state.current_input_row++;
+				continue;
+			}
+
+			state.current_rows.clear();
+			git_repository *repo = nullptr;
+			int error = git_repository_open(&repo, repo_path.c_str());
+			if (error != 0) {
+				state.current_input_row++;
+				continue;
+			}
+			try {
+				// Populate identity fields on each row via caller post-process below.
+				CollectBlameRows(repo, repo_path, file_path, revision, bind_data.opts, per_line, state.current_rows);
+			} catch (...) {
+				git_repository_free(repo);
+				state.current_input_row++;
+				continue;
+			}
+			git_repository_free(repo);
+
+			state.initialized_row = true;
+			state.current_output_row = 0;
+		}
+
+		idx_t output_count = 0;
+		while (output_count < STANDARD_VECTOR_SIZE && state.current_output_row < state.current_rows.size()) {
+			if (per_line) {
+				OutputBlameRow(output, state.current_rows[state.current_output_row], output_count);
+			} else {
+				OutputHunkRow(output, state.current_rows[state.current_output_row], output_count);
+			}
+			state.current_output_row++;
+			output_count++;
+		}
+		output.SetCardinality(output_count);
+
+		if (state.current_output_row >= state.current_rows.size()) {
+			state.current_input_row++;
+			state.initialized_row = false;
+		}
+
+		if (output_count > 0) {
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+	}
+}
+
+static OperatorResultType GitBlameHunksEachFunction(ExecutionContext &context, TableFunctionInput &data_p,
+                                                     DataChunk &input, DataChunk &output) {
+	return GitBlameEachImpl(context, data_p, input, output, /*per_line=*/false);
+}
+```
+
+- [ ] **Step 4: Register `git_blame_hunks_each`**
+
+Extend `RegisterGitBlameFunction` body (add below the existing registrations, before the closing brace):
+
+```cpp
+	auto declare_lateral_params = [](TableFunction &fn) {
+		fn.named_parameters["revision"] = LogicalType::VARCHAR;
+		fn.named_parameters["min_line"] = LogicalType::BIGINT;
+		fn.named_parameters["max_line"] = LogicalType::BIGINT;
+		fn.named_parameters["ignore_whitespace"] = LogicalType::BOOLEAN;
+		fn.named_parameters["use_mailmap"] = LogicalType::BOOLEAN;
+		fn.named_parameters["first_parent"] = LogicalType::BOOLEAN;
+	};
+
+	TableFunctionSet git_blame_hunks_each_set("git_blame_hunks_each");
+	TableFunction hunks_each_one({LogicalType::VARCHAR}, nullptr, GitBlameHunksEachBind, GitBlameInitGlobal,
+	                              GitBlameLocalInit);
+	hunks_each_one.in_out_function = GitBlameHunksEachFunction;
+	declare_lateral_params(hunks_each_one);
+	git_blame_hunks_each_set.AddFunction(hunks_each_one);
+
+	TableFunction hunks_each_two({LogicalType::VARCHAR, LogicalType::VARCHAR}, nullptr, GitBlameHunksEachBind,
+	                              GitBlameInitGlobal, GitBlameLocalInit);
+	hunks_each_two.in_out_function = GitBlameHunksEachFunction;
+	declare_lateral_params(hunks_each_two);
+	git_blame_hunks_each_set.AddFunction(hunks_each_two);
+
+	loader.RegisterFunction(git_blame_hunks_each_set);
+```
+
+- [ ] **Step 5: Build and run**
+
+Run:
+
+```bash
+make debug -j && make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/git_blame.cpp test/sql/git_blame.test
+git commit -m "Add git_blame_hunks_each LATERAL variant (issue #18)"
+```
+
+---
+
+## Task 9: `git_blame_each` LATERAL variant + per-row revision
+
+**Files:**
+- Modify: `src/git_blame.cpp`
+- Modify: `test/sql/git_blame.test`
+
+Goal: add the per-line LATERAL form and verify second-positional revision works.
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# git_blame_each: basic per-line via LATERAL
+query III
+SELECT v.f, g.line_number, g.author_name
+FROM (VALUES ('test/tmp/main-repo/README.md')) AS v(f),
+     LATERAL git_blame_each(v.f) g
+ORDER BY v.f, g.line_number
+----
+test/tmp/main-repo/README.md	1	Test User
+test/tmp/main-repo/README.md	2	Test User
+
+# git_blame_each with a per-row revision override (second LATERAL column)
+query II
+SELECT g.line_number, g.author_name
+FROM (VALUES ('test/tmp/main-repo/README.md', 'HEAD')) AS v(f, r),
+     LATERAL git_blame_each(v.f, v.r) g
+ORDER BY g.line_number
+----
+1	Test User
+2	Test User
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: FAIL — `git_blame_each` does not exist.
+
+- [ ] **Step 3: Add bind + exec wrappers**
+
+In `src/git_blame.cpp`, **next to** `GitBlameHunksEachBind` / `GitBlameHunksEachFunction`, add the per-line variants:
+
+```cpp
+static unique_ptr<FunctionData> GitBlameEachBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	DefineBlameSchema(return_types, names);
+	return GitBlameLateralBind(context, input, /*per_line=*/true);
+}
+
+static OperatorResultType GitBlameEachFunction(ExecutionContext &context, TableFunctionInput &data_p,
+                                                DataChunk &input, DataChunk &output) {
+	return GitBlameEachImpl(context, data_p, input, output, /*per_line=*/true);
+}
+```
+
+- [ ] **Step 4: Register `git_blame_each`**
+
+Add to `RegisterGitBlameFunction`, below the `git_blame_hunks_each` registration:
+
+```cpp
+	TableFunctionSet git_blame_each_set("git_blame_each");
+	TableFunction blame_each_one({LogicalType::VARCHAR}, nullptr, GitBlameEachBind, GitBlameInitGlobal,
+	                              GitBlameLocalInit);
+	blame_each_one.in_out_function = GitBlameEachFunction;
+	declare_lateral_params(blame_each_one);
+	git_blame_each_set.AddFunction(blame_each_one);
+
+	TableFunction blame_each_two({LogicalType::VARCHAR, LogicalType::VARCHAR}, nullptr, GitBlameEachBind,
+	                              GitBlameInitGlobal, GitBlameLocalInit);
+	blame_each_two.in_out_function = GitBlameEachFunction;
+	declare_lateral_params(blame_each_two);
+	git_blame_each_set.AddFunction(blame_each_two);
+
+	loader.RegisterFunction(git_blame_each_set);
+```
+
+- [ ] **Step 5: Build and run**
+
+Run:
+
+```bash
+make debug -j && make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/git_blame.cpp test/sql/git_blame.test
+git commit -m "Add git_blame_each LATERAL variant (issue #18)"
+```
+
+---
+
+## Task 10: Error-path tests
+
+**Files:**
+- Modify: `test/sql/git_blame.test`
+
+Goal: verify we surface clean errors for the common failure modes.
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# Nonexistent file in an existing repo
+statement error
+SELECT * FROM git_blame('does-not-exist.md', repo_path := 'test/tmp/main-repo')
+----
+
+# Nonexistent revision
+statement error
+SELECT * FROM git_blame('test/tmp/main-repo/README.md', revision := 'this-ref-does-not-exist')
+----
+
+# Nonexistent repository path
+statement error
+SELECT * FROM git_blame('README.md', repo_path := '/nonexistent/repo/path')
+----
+```
+
+- [ ] **Step 2: Build (no code changes expected) and run**
+
+Run:
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS. If any test does *not* error, inspect what the binder returned and either (a) add validation in the binder to raise the expected error, or (b) relax the test to match the existing behavior. Prefer (a).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/sql/git_blame.test
+git commit -m "Add error-path tests for git_blame (issue #18)"
+```
+
+---
+
+## Task 11: Schema assertion tests
+
+**Files:**
+- Modify: `test/sql/git_blame.test`
+
+Goal: pin the column count and names for all four functions so future refactors can't silently drift the schema.
+
+- [ ] **Step 1: Add tests**
+
+Append to `test/sql/git_blame.test`:
+
+```
+
+# git_blame per-line column count = 14
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame('test/tmp/main-repo/README.md'))
+----
+14
+
+# git_blame_hunks column count = 14
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame_hunks('test/tmp/main-repo/README.md'))
+----
+14
+
+# git_blame has line_number and line_content columns
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame('test/tmp/main-repo/README.md'))
+WHERE column_name IN ('line_number', 'line_content')
+----
+2
+
+# git_blame_hunks has start_line and line_count columns
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame_hunks('test/tmp/main-repo/README.md'))
+WHERE column_name IN ('start_line', 'line_count')
+----
+2
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+make test_debug TESTS_BASE_DIRECTORY=test/sql/git_blame
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/sql/git_blame.test
+git commit -m "Pin git_blame schema with column-count tests (issue #18)"
+```
+
+---
+
+## Task 12: Reference documentation
+
+**Files:**
+- Create: `docs/reference/git_blame.md`
+
+Goal: user-facing docs following the shape of `docs/reference/git_read.md`.
+
+- [ ] **Step 1: Write the doc**
+
+Create `docs/reference/git_blame.md`:
+
+```markdown
+# git_blame
+
+Return line-level authorship ("blame") for a file at a specific revision.
+Analogous to `git blame <rev> -- <path>`, but as a composable DuckDB table.
+
+Two output shapes are available:
+
+- `git_blame` — one row per line of the file, with `line_content`. Best for
+  joining against AST line ranges or per-line analysis.
+- `git_blame_hunks` — one row per libgit2 blame hunk (contiguous range of
+  lines from the same commit). Cheaper if you don't need line content.
+
+Both come in a static form and an `_each` LATERAL variant.
+
+## Syntax
+
+```sql
+git_blame(file_path_or_uri)
+git_blame(file_path_or_uri, revision := 'HEAD', repo_path := '.')
+
+git_blame_hunks(file_path_or_uri)
+git_blame_hunks(file_path_or_uri, revision := 'HEAD', repo_path := '.')
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| (positional) | VARCHAR | — | Either a `git://` URI that embeds the repo, file, and revision, or a plain file path. |
+| `repo_path` | VARCHAR | `.` | Repository path. Ignored when the positional is a `git://` URI. |
+| `revision` | VARCHAR | `HEAD` | Revision to blame at (SHA, branch, tag, or `HEAD~N`). |
+| `min_line` | BIGINT | 1 | Lower bound for lines to blame (1-indexed, inclusive). |
+| `max_line` | BIGINT | last line | Upper bound for lines to blame (inclusive). |
+| `ignore_whitespace` | BOOLEAN | `false` | Sets libgit2's `GIT_BLAME_IGNORE_WHITESPACE`. |
+| `use_mailmap` | BOOLEAN | `false` | Sets libgit2's `GIT_BLAME_USE_MAILMAP`. |
+| `first_parent` | BOOLEAN | `false` | Sets libgit2's `GIT_BLAME_FIRST_PARENT`. |
+
+## Output — `git_blame`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `repo_path` | VARCHAR | Absolute repository path |
+| `file_path` | VARCHAR | Path within the repository |
+| `file_ext` | VARCHAR | File extension |
+| `revision` | VARCHAR | Revision requested |
+| `line_number` | BIGINT | 1-indexed line in the file at `revision` |
+| `line_content` | VARCHAR | Text of that line; NULL for binary files |
+| `commit_hash` | VARCHAR | Commit that last touched this line |
+| `author_name` | VARCHAR | Author of `commit_hash` |
+| `author_email` | VARCHAR | Author email |
+| `author_date` | TIMESTAMP | Author timestamp |
+| `orig_commit_hash` | VARCHAR | Commit where this line was introduced |
+| `orig_path` | VARCHAR | Path in `orig_commit_hash` (same as `file_path` unless libgit2 detected a rename) |
+| `orig_line_number` | BIGINT | Line number in `orig_path` at `orig_commit_hash` |
+| `boundary` | BOOLEAN | True if the hunk reached the oldest commit boundary |
+
+## Output — `git_blame_hunks`
+
+Same columns as `git_blame` except `line_number`/`line_content`/`orig_line_number`
+are replaced with:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `start_line` | BIGINT | 1-indexed first line of the hunk |
+| `line_count` | BIGINT | Number of lines in the hunk |
+| `orig_start_line` | BIGINT | Start line in `orig_path` at `orig_commit_hash` |
+
+## Examples
+
+### Basic blame
+
+```sql
+SELECT line_number, author_name, line_content
+FROM git_blame('src/auth.py', repo_path := '.');
+```
+
+### Using a git:// URI
+
+```sql
+SELECT line_number, author_name
+FROM git_blame('git://src/auth.py@HEAD');
+```
+
+### Restrict to a line range (AST node)
+
+```sql
+SELECT line_number, commit_hash, author_name
+FROM git_blame('src/auth.py', min_line := 42, max_line := 57);
+```
+
+### Hunk view
+
+```sql
+SELECT start_line, line_count, commit_hash, author_date
+FROM git_blame_hunks('src/auth.py')
+ORDER BY start_line;
+```
+
+## LATERAL variants
+
+### Blame many files in one query
+
+```sql
+SELECT t.file_path, b.line_number, b.author_name
+FROM git_tree('HEAD') t,
+     LATERAL git_blame_each(t.git_uri) b
+WHERE t.file_ext = '.py';
+```
+
+### Blame the same file across a commit history
+
+```sql
+SELECT l.commit_hash, l.author_date, b.author_name
+FROM git_log() l,
+     LATERAL git_blame_each('src/auth.py', l.commit_hash) b
+WHERE b.line_number = 1
+LIMIT 10;
+```
+
+### Join against an AST table (pluckit-style)
+
+```sql
+SELECT a.node_id, b.author_name, b.author_date
+FROM my_ast_nodes a,
+     LATERAL git_blame_each(
+         a.file_path,
+         min_line := a.start_line,
+         max_line := a.end_line) b;
+```
+
+## Notes
+
+- **Rename tracking across files** is defined by libgit2's
+  `GIT_BLAME_TRACK_COPIES_*` flags but those are currently unimplemented in
+  libgit2. `orig_path` will almost always equal `file_path` until a future
+  libgit2 release. `git_blame` does not expose those flags today.
+- **Binary files** return `line_content` as NULL in `git_blame`. Use
+  `git_blame_hunks` if you want authorship without line content.
+- **Very long lines** (e.g. minified JS) are returned in full in `line_content`.
+  Use `min_line`/`max_line` to restrict blame to a manageable range.
+- `min_line`/`max_line` are passed directly to libgit2, so restricting a range
+  is cheap — the blame computation itself only walks commits that touched the
+  requested lines.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/reference/git_blame.md
+git commit -m "Add git_blame reference documentation (issue #18)"
+```
+
+---
+
+## Task 13: Final verification
+
+**Files:** none
+
+Goal: run the full test suite, not just the blame file, and verify the build is clean.
+
+- [ ] **Step 1: Full test run**
+
+```bash
+make test_debug
+```
+
+Expected: all tests pass (blame + all pre-existing tests).
+
+- [ ] **Step 2: Release build sanity check**
+
+```bash
+make release -j
+```
+
+Expected: release build succeeds.
+
+- [ ] **Step 3: Confirm all four functions exist in a clean session**
+
+```bash
+./build/release/duckdb -unsigned -c "LOAD './build/release/extension/duck_tails/duck_tails.duckdb_extension'; SELECT function_name FROM duckdb_functions() WHERE function_name LIKE 'git_blame%' ORDER BY function_name;"
+```
+
+Expected output includes: `git_blame`, `git_blame_each`, `git_blame_hunks`, `git_blame_hunks_each`.
+
+- [ ] **Step 4: Final commit if anything was adjusted during verification**
+
+If nothing changed, skip. Otherwise:
+
+```bash
+git add -u
+git commit -m "Fix issues caught during final verification (issue #18)"
+```

--- a/docs/superpowers/specs/2026-04-11-git-blame-design.md
+++ b/docs/superpowers/specs/2026-04-11-git-blame-design.md
@@ -1,0 +1,289 @@
+# git_blame table function — design
+
+**Issue:** [#18](https://github.com/teaguesterling/duck_tails/issues/18)
+**Date:** 2026-04-11
+**Branch:** `issue/18-git_blame`
+
+## Summary
+
+Add `git_blame` and `git_blame_hunks` table functions (plus `_each` LATERAL
+variants) for line-level authorship lookup. Primary consumer is the pluckit
+History plugin, which needs to join AST node line ranges against blame output to
+answer "who last touched this function?".
+
+`git_blame` returns one row per line with `line_content`; `git_blame_hunks`
+returns one row per libgit2 blame hunk (native shape, cheaper). Both share a
+single implementation core that wraps libgit2's `git_blame_file`.
+
+## Motivation
+
+`git_log --path` gives file-level history, but pluckit needs line-level. Without
+this function, implementing per-line blame requires iterating the whole commit
+history and diffing per commit, which is prohibitively expensive.
+`libgit2` already exposes `git_blame_file` with native `min_line`/`max_line`
+range restriction, so the downstream cost can be made proportional to the AST
+node's line range rather than to the whole file.
+
+## Non-goals
+
+- **Rename tracking across files.** libgit2 defines
+  `GIT_BLAME_TRACK_COPIES_*` flags but the shipped implementation leaves them
+  unimplemented. `orig_path` will still be surfaced (free from the hunk struct)
+  but will almost always equal `file_path` until libgit2 gains real rename
+  tracking.
+- **Committer fields.** Blame is author-centric and adding committer columns now
+  would double the signature churn. Cheap to add later if demand appears.
+- **Caching / incremental blame.** `git_blame_buffer` exists but is only useful
+  for blaming an in-memory modified buffer against a cached committed blame —
+  not the shape we want.
+
+## Functions
+
+Four table functions, all registered from a new `src/git_blame.cpp`:
+
+| Function | Shape | Context |
+|---|---|---|
+| `git_blame` | one row per line | static |
+| `git_blame_each` | one row per line | LATERAL |
+| `git_blame_hunks` | one row per hunk | static |
+| `git_blame_hunks_each` | one row per hunk | LATERAL |
+
+### Signatures — static
+
+```sql
+git_blame(file_uri)
+git_blame(file_path, repo_path := '...', revision := 'HEAD')
+```
+
+Same two forms for `git_blame_hunks`. The first positional argument is either a
+`git://` URI (in which case `repo_path` / `revision` are ignored) or a plain
+file path (resolved against `repo_path`, default `.`, at `revision`, default
+`HEAD`). This mirrors `git_read`'s convention.
+
+### Signatures — LATERAL
+
+```sql
+git_blame_each(file_uri)
+git_blame_each(file_uri, revision)
+```
+
+Same two forms for `git_blame_hunks_each`. Matches `git_read_each`: first
+positional LATERAL input is the URI/path, second optional LATERAL input is the
+per-row revision override. If only the 1-arg form is used, each row is blamed
+at the bind-time `revision` named parameter (default `HEAD`). A `git://` URI
+that embeds its own `@rev` takes precedence over both. Enables blaming the
+same file across many commits in one query:
+
+```sql
+SELECT l.commit_hash, b.line_number, b.author_name
+FROM git_log() l,
+     LATERAL git_blame_each('src/auth.py', l.commit_hash) b;
+```
+
+### Named parameters (all four functions)
+
+| Name | Type | Default | Effect |
+|---|---|---|---|
+| `repo_path` | VARCHAR | `.` | Repo path when first positional is a plain path (ignored for `git://` URIs). |
+| `revision` | VARCHAR | `HEAD` | Revision to blame (static form only; LATERAL uses second positional). |
+| `min_line` | BIGINT | 1 | Lower bound (1-indexed, inclusive). Passed to `git_blame_options.min_line`. |
+| `max_line` | BIGINT | end of file | Upper bound (inclusive). Passed to `git_blame_options.max_line`. |
+| `ignore_whitespace` | BOOLEAN | false | Sets `GIT_BLAME_IGNORE_WHITESPACE`. |
+| `use_mailmap` | BOOLEAN | false | Sets `GIT_BLAME_USE_MAILMAP`. |
+| `first_parent` | BOOLEAN | false | Sets `GIT_BLAME_FIRST_PARENT`. |
+
+`min_line` / `max_line` validation: both must be ≥ 1, and if both are set,
+`min_line <= max_line`. Violations raise `BinderException`.
+
+## Output schemas
+
+### `git_blame` — one row per line
+
+| Column | Type | Source |
+|---|---|---|
+| `repo_path` | VARCHAR | resolved absolute repo path |
+| `file_path` | VARCHAR | resolved file path within repo |
+| `file_ext` | VARCHAR | derived |
+| `revision` | VARCHAR | resolved revision string (the one passed, not the SHA) |
+| `line_number` | BIGINT | 1-indexed line in file at revision |
+| `line_content` | VARCHAR | text of that line (from blob); NULL for binary files |
+| `commit_hash` | VARCHAR | `hunk.final_commit_id` |
+| `author_name` | VARCHAR | `hunk.final_signature->name` |
+| `author_email` | VARCHAR | `hunk.final_signature->email` |
+| `author_date` | TIMESTAMP | `hunk.final_signature->when` |
+| `orig_commit_hash` | VARCHAR | `hunk.orig_commit_id` |
+| `orig_path` | VARCHAR | `hunk.orig_path` |
+| `orig_line_number` | BIGINT | `hunk.orig_start_line_number + (line - hunk.final_start_line_number)` |
+| `boundary` | BOOLEAN | `hunk.boundary != 0` |
+
+14 columns.
+
+### `git_blame_hunks` — one row per hunk
+
+Same as `git_blame`, with two swaps:
+
+- `line_number` → `start_line` (`hunk.final_start_line_number`)
+- `line_content` → `line_count` BIGINT (`hunk.lines_in_hunk`)
+- `orig_line_number` → `orig_start_line` (`hunk.orig_start_line_number`)
+
+14 columns total. The full ordered column list is: `repo_path`, `file_path`,
+`file_ext`, `revision`, `start_line`, `line_count`, `commit_hash`,
+`author_name`, `author_email`, `author_date`, `orig_commit_hash`, `orig_path`,
+`orig_start_line`, `boundary`.
+
+## Implementation
+
+### File layout
+
+Single new file `src/git_blame.cpp`, similar shape and size to
+`src/git_diff_tree.cpp`. Shared helpers for the two output shapes live inside
+the file; no new headers required beyond forward declarations in
+`src/include/git_functions.hpp`.
+
+### Data flow
+
+1. **Bind**: parse first positional (URI vs plain path) via existing
+   `ParseUnifiedGitParams` / `GitPath::Parse`. Validate `min_line`/`max_line`.
+   Store `repo_path`, `file_path`, `revision`, and blame options in bind data.
+2. **Init / execute**:
+   - Open repo with `git_repository_open`.
+   - `git_revparse_single` on `revision` → commit OID → set
+     `opts.newest_commit`.
+   - `git_blame_file(&blame, repo, file_path, &opts)`.
+   - For `git_blame`: load blob at `file_path` from commit tree via
+     `git_tree_entry_bypath` + `git_blob_lookup`. Binary check via
+     `git_blob_is_binary`. If text, split content into lines by `\n` (strip
+     trailing `\r`), storing a `vector<string_view>` indexed by 1-based line
+     number. If binary, skip the split and leave `line_content` NULL for all
+     emitted rows.
+   - For `git_blame_hunks`: no blob load.
+   - Iterate `git_blame_get_hunk_count` hunks. Apply `min_line`/`max_line`
+     clipping client-side as a safety net (libgit2 already restricts, but hunks
+     that cross the boundary are possible in theory).
+   - **`git_blame`**: for each hunk, emit `lines_in_hunk` rows, one per line,
+     computing `line_number = hunk.final_start_line_number + offset`,
+     `orig_line_number = hunk.orig_start_line_number + offset`, and pulling
+     `line_content` from the split blob by `line_number`.
+   - **`git_blame_hunks`**: emit one row per hunk directly.
+3. **LATERAL variants**: follow the `git_read_each` pattern. Runtime input
+   chunk column 0 = URI/path, optional column 1 = revision override. Bind-time
+   named parameters supply all other options. Per-input-row blame call, buffer
+   results in `LocalState.current_rows`, emit up to `STANDARD_VECTOR_SIZE` at a
+   time, return `HAVE_MORE_OUTPUT` / `NEED_MORE_INPUT` per the existing
+   convention.
+
+### Shared blame core
+
+```cpp
+struct GitBlameRow {
+  string commit_hash;
+  string author_name;
+  string author_email;
+  timestamp_t author_date;
+  string orig_commit_hash;
+  string orig_path;
+  idx_t orig_line_number;   // resolved per line for git_blame
+  idx_t line_number;        // for git_blame; unused for hunks
+  idx_t start_line;         // for hunks; unused for git_blame
+  idx_t line_count;         // for hunks; unused for git_blame
+  string line_content;      // for git_blame; empty for hunks
+  bool boundary;
+};
+
+// Computes blame hunks and (for per-line mode) loads and splits the blob.
+// `per_line` controls whether hunks are expanded into per-line rows and whether
+// the blob is loaded for line_content.
+static void CollectBlameRows(
+    git_repository *repo,
+    const string &file_path,
+    const string &revision,
+    const GitBlameOptions &opts,
+    bool per_line,
+    vector<GitBlameRow> &rows);
+```
+
+Both `git_blame` and `git_blame_hunks` call `CollectBlameRows`; only the
+row-to-column mapping differs. The `_each` variants call it once per LATERAL
+input row.
+
+### Error handling
+
+All error paths raise `IOException` or `BinderException` to stay consistent
+with the rest of the codebase:
+
+- Binder errors: invalid `min_line`/`max_line`, empty/unparseable file URI.
+- IO errors (wrapped from libgit2 `git_error_last`): repository open failure,
+  revision parse failure, file not found at revision, blame computation
+  failure, blob lookup failure.
+- Empty file: returns zero rows (not an error).
+- Binary file: `git_blame` returns rows with NULL `line_content`; `git_blame_hunks`
+  returns rows normally (no blob load attempted).
+
+### Registration
+
+- `src/include/git_functions.hpp`: declare
+  `void RegisterGitBlameFunction(ExtensionLoader &loader);`.
+- `src/git_functions.cpp`: add `RegisterGitBlameFunction(loader);` to
+  `RegisterGitFunctions`.
+- `CMakeLists.txt`: add `src/git_blame.cpp` to the extension source list.
+
+## Testing
+
+New test file `test/sql/git_blame.test` using the existing
+`test/tmp/main-repo` fixture (2 commits, README.md + src/main.cpp).
+
+Coverage:
+
+1. **Schema**: `DESCRIBE` column count and names for all four functions.
+2. **Basic per-line blame**: `git_blame('README.md', repo_path := 'test/tmp/main-repo')`.
+   Assert `count(*)` equals file line count; assert `author_name` on known
+   lines; assert `line_content` matches expected text for line 1.
+3. **URI form**: `git_blame('git://test/tmp/main-repo/README.md@HEAD')` produces
+   identical output to the plain-path form.
+4. **Revision forms**: `revision := 'HEAD~1'`, branch name, tag, full SHA —
+   each returns expected line counts and authors.
+5. **`min_line` / `max_line`**: restrict to a 3-line window; assert row count
+   equals 3 and `line_number` values are in range.
+6. **`min_line > max_line`**: expect `BinderException`.
+7. **Option flags**: `ignore_whitespace`, `use_mailmap`, `first_parent` —
+   smoke test that each accepts the param and returns results (behavioral
+   verification deferred; these are libgit2-native).
+8. **`git_blame_hunks`**: assert hunks exist; assert
+   `sum(line_count)` equals file line count; assert `start_line` of first hunk
+   is 1.
+9. **LATERAL `git_blame_each`**: `git_tree(...) → LATERAL git_blame_each(git_uri)`
+   over a small tree; assert each file's rows are grouped correctly.
+10. **LATERAL with per-row revision**:
+    `git_log() → LATERAL git_blame_each('README.md', l.commit_hash)` — verifies
+    revision flows through LATERAL.
+11. **Error paths**: nonexistent file, nonexistent revision, repository open
+    failure.
+12. **Empty file**: returns zero rows.
+13. **Binary file** (small fixture binary, or create one in setup): `git_blame`
+    returns rows with NULL `line_content`; `git_blame_hunks` returns normally.
+
+### Docs
+
+New `docs/reference/git_blame.md` following the format of
+`docs/reference/git_read.md`. Covers syntax, named parameters, output schema
+for both functions, examples (URI form, explicit form, `min_line`/`max_line`,
+LATERAL joining against `git_log`, pluckit-style join against an AST table).
+
+## Risks
+
+- **Binary file handling**: libgit2 will happily blame a binary file. The design
+  treats binary as "rows with NULL `line_content`" but the hunk structure may
+  not correspond to meaningful "lines". Tests need to verify this doesn't
+  crash or produce garbage in `line_content`.
+- **Very long lines**: `line_content` as `VARCHAR` has no length cap. If a
+  minified JS file has a single 2MB line, that row will be 2MB. Not addressing
+  this in v1 — `max_line` is the escape valve. Documented as a caveat.
+- **UTF-8 validation**: existing `git_read` has custom UTF-8 validation to
+  prevent verification crashes. We need the same treatment when populating
+  `line_content`. The blame core should reuse `git_read`'s `IsValidUTF8` helper
+  — extract it into `git_utils.hpp` or duplicate until a third caller shows up.
+  I'll duplicate for now and note the extraction opportunity.
+- **libgit2 memory ownership**: `git_blame_hunk` contents (signatures, orig_path
+  strings) are owned by the `git_blame` struct. We must copy all string data
+  out before calling `git_blame_free`. The `GitBlameRow` struct uses owning
+  `string`s, which covers this correctly as long as we copy *before* the free.

--- a/docs/superpowers/specs/2026-04-11-git-blame-design.md
+++ b/docs/superpowers/specs/2026-04-11-git-blame-design.md
@@ -69,10 +69,13 @@ git_blame_each(file_uri, revision)
 
 Same two forms for `git_blame_hunks_each`. Matches `git_read_each`: first
 positional LATERAL input is the URI/path, second optional LATERAL input is the
-per-row revision override. If only the 1-arg form is used, each row is blamed
-at the bind-time `revision` named parameter (default `HEAD`). A `git://` URI
-that embeds its own `@rev` takes precedence over both. Enables blaming the
-same file across many commits in one query:
+per-row revision override. Revision resolution order per row:
+
+1. Second LATERAL positional (if present and non-NULL) — wins unconditionally.
+2. Non-default `@rev` embedded in the input `git://` URI.
+3. Bind-time `revision` named parameter (default `HEAD`).
+
+Enables blaming the same file across many commits in one query:
 
 ```sql
 SELECT l.commit_hash, b.line_number, b.author_name

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -1,0 +1,21 @@
+#include "duckdb.hpp"
+#include "git_functions.hpp"
+#include "git_filesystem.hpp"
+#include "git_path.hpp"
+#include "git_context_manager.hpp"
+#include "git_utils.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/common/exception.hpp"
+
+#include <git2.h>
+
+namespace duckdb {
+
+void RegisterGitBlameFunction(ExtensionLoader &loader) {
+	// Functions will be registered in later tasks.
+	(void)loader;
+}
+
+} // namespace duckdb

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -210,8 +210,7 @@ static void CollectBlameRows(git_repository *repo, const string &repo_path, cons
 		string commit_hash = OidToHex(&hunk->final_commit_id);
 		string orig_commit_hash = OidToHex(&hunk->orig_commit_id);
 		string author_name = hunk->final_signature && hunk->final_signature->name ? hunk->final_signature->name : "";
-		string author_email =
-		    hunk->final_signature && hunk->final_signature->email ? hunk->final_signature->email : "";
+		string author_email = hunk->final_signature && hunk->final_signature->email ? hunk->final_signature->email : "";
 		timestamp_t author_date = timestamp_t(0);
 		if (hunk->final_signature) {
 			// libgit2 git_time is seconds since epoch (UTC).
@@ -275,13 +274,13 @@ static void CollectBlameRows(git_repository *repo, const string &repo_path, cons
 //===--------------------------------------------------------------------===//
 
 static void DefineHunksSchema(vector<LogicalType> &return_types, vector<string> &names) {
-	return_types = {LogicalType::VARCHAR,   LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
-	                LogicalType::BIGINT,    LogicalType::BIGINT,    LogicalType::VARCHAR,  LogicalType::VARCHAR,
-	                LogicalType::VARCHAR,   LogicalType::TIMESTAMP, LogicalType::VARCHAR,  LogicalType::VARCHAR,
-	                LogicalType::BIGINT,    LogicalType::BOOLEAN};
-	names = {"repo_path",        "file_path",   "file_ext",         "revision",     "start_line",
-	         "line_count",       "commit_hash", "author_name",      "author_email", "author_date",
-	         "orig_commit_hash", "orig_path",   "orig_start_line",  "boundary"};
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR,   LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::BIGINT,  LogicalType::BIGINT,    LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::VARCHAR, LogicalType::TIMESTAMP, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::BIGINT,  LogicalType::BOOLEAN};
+	names = {"repo_path",        "file_path",   "file_ext",        "revision",     "start_line",
+	         "line_count",       "commit_hash", "author_name",     "author_email", "author_date",
+	         "orig_commit_hash", "orig_path",   "orig_start_line", "boundary"};
 }
 
 static void OutputHunkRow(DataChunk &output, const GitBlameRow &row, idx_t row_idx) {
@@ -310,7 +309,7 @@ struct GitBlameBindData : public TableFunctionData {
 	string file_path;
 	string revision;
 	GitBlameOptions opts;
-	bool per_line = true;  // false for *_hunks variants
+	bool per_line = true; // false for *_hunks variants
 	bool is_lateral = false;
 	vector<GitBlameRow> rows; // Materialized at bind time for static forms
 };
@@ -339,8 +338,8 @@ static void ValidateBlameOptions(const GitBlameOptions &opts, const char *func_n
 		throw BinderException("%s: max_line must be >= 1", func_name);
 	}
 	if (opts.min_line > 0 && opts.max_line > 0 && opts.min_line > opts.max_line) {
-		throw BinderException("%s: min_line (%lld) must be <= max_line (%lld)", func_name,
-		                      (long long)opts.min_line, (long long)opts.max_line);
+		throw BinderException("%s: min_line (%lld) must be <= max_line (%lld)", func_name, (long long)opts.min_line,
+		                      (long long)opts.max_line);
 	}
 }
 
@@ -446,8 +445,8 @@ static unique_ptr<GlobalTableFunctionState> GitBlameInitGlobal(ClientContext &co
 	return make_uniq<GlobalTableFunctionState>();
 }
 
-static unique_ptr<LocalTableFunctionState>
-GitBlameLocalInit(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
+static unique_ptr<LocalTableFunctionState> GitBlameLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
+                                                             GlobalTableFunctionState *global_state) {
 	return make_uniq<GitBlameLocalState>();
 }
 
@@ -469,10 +468,10 @@ static void GitBlameHunksFunction(ClientContext &context, TableFunctionInput &da
 //===--------------------------------------------------------------------===//
 
 static void DefineBlameSchema(vector<LogicalType> &return_types, vector<string> &names) {
-	return_types = {LogicalType::VARCHAR,   LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
-	                LogicalType::BIGINT,    LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
-	                LogicalType::VARCHAR,   LogicalType::TIMESTAMP, LogicalType::VARCHAR,  LogicalType::VARCHAR,
-	                LogicalType::BIGINT,    LogicalType::BOOLEAN};
+	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR,   LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::BIGINT,  LogicalType::VARCHAR,   LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::VARCHAR, LogicalType::TIMESTAMP, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                LogicalType::BIGINT,  LogicalType::BOOLEAN};
 	names = {"repo_path",        "file_path",   "file_ext",         "revision",     "line_number",
 	         "line_content",     "commit_hash", "author_name",      "author_email", "author_date",
 	         "orig_commit_hash", "orig_path",   "orig_line_number", "boundary"};
@@ -500,7 +499,7 @@ static void OutputBlameRow(DataChunk &output, const GitBlameRow &row, idx_t row_
 }
 
 static unique_ptr<FunctionData> GitBlameBind(ClientContext &context, TableFunctionBindInput &input,
-                                              vector<LogicalType> &return_types, vector<string> &names) {
+                                             vector<LogicalType> &return_types, vector<string> &names) {
 	DefineBlameSchema(return_types, names);
 
 	if (input.inputs.empty()) {
@@ -585,7 +584,7 @@ static void GitBlameFunction(ClientContext &context, TableFunctionInput &data_p,
 // data; the runtime file path/URI and optional revision come from the input
 // DataChunk per row.
 static unique_ptr<FunctionData> GitBlameLateralBind(ClientContext &context, TableFunctionBindInput &input,
-                                                     bool per_line) {
+                                                    bool per_line) {
 	auto bind_data = make_uniq<GitBlameBindData>();
 	bind_data->per_line = per_line;
 	bind_data->is_lateral = true;
@@ -636,7 +635,7 @@ static void ResolveLateralInput(const string &raw_input, const string &bind_revi
 }
 
 static OperatorResultType GitBlameEachImpl(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
-                                            DataChunk &output, bool per_line) {
+                                           DataChunk &output, bool per_line) {
 	auto &state = data_p.local_state->Cast<GitBlameLocalState>();
 	auto &bind_data = data_p.bind_data->Cast<GitBlameBindData>();
 
@@ -655,14 +654,13 @@ static OperatorResultType GitBlameEachImpl(ExecutionContext &context, TableFunct
 			}
 
 			auto file_vec = FlatVector::GetData<string_t>(input.data[0]);
-			string raw_input(file_vec[state.current_input_row].GetData(),
-			                 file_vec[state.current_input_row].GetSize());
+			string raw_input(file_vec[state.current_input_row].GetData(), file_vec[state.current_input_row].GetSize());
 
 			string row_revision;
 			if (input.ColumnCount() > 1 && !FlatVector::IsNull(input.data[1], state.current_input_row)) {
 				auto rev_vec = FlatVector::GetData<string_t>(input.data[1]);
-				row_revision = string(rev_vec[state.current_input_row].GetData(),
-				                      rev_vec[state.current_input_row].GetSize());
+				row_revision =
+				    string(rev_vec[state.current_input_row].GetData(), rev_vec[state.current_input_row].GetSize());
 			}
 
 			string repo_path, file_path, revision;
@@ -718,18 +716,18 @@ static OperatorResultType GitBlameEachImpl(ExecutionContext &context, TableFunct
 }
 
 static OperatorResultType GitBlameHunksEachFunction(ExecutionContext &context, TableFunctionInput &data_p,
-                                                     DataChunk &input, DataChunk &output) {
+                                                    DataChunk &input, DataChunk &output) {
 	return GitBlameEachImpl(context, data_p, input, output, /*per_line=*/false);
 }
 
 static unique_ptr<FunctionData> GitBlameEachBind(ClientContext &context, TableFunctionBindInput &input,
-                                                  vector<LogicalType> &return_types, vector<string> &names) {
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
 	DefineBlameSchema(return_types, names);
 	return GitBlameLateralBind(context, input, /*per_line=*/true);
 }
 
-static OperatorResultType GitBlameEachFunction(ExecutionContext &context, TableFunctionInput &data_p,
-                                                DataChunk &input, DataChunk &output) {
+static OperatorResultType GitBlameEachFunction(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+                                               DataChunk &output) {
 	return GitBlameEachImpl(context, data_p, input, output, /*per_line=*/true);
 }
 
@@ -773,13 +771,13 @@ void RegisterGitBlameFunction(ExtensionLoader &loader) {
 
 	TableFunctionSet git_blame_hunks_each_set("git_blame_hunks_each");
 	TableFunction hunks_each_one({LogicalType::VARCHAR}, nullptr, GitBlameHunksEachBind, GitBlameInitGlobal,
-	                              GitBlameLocalInit);
+	                             GitBlameLocalInit);
 	hunks_each_one.in_out_function = GitBlameHunksEachFunction;
 	declare_lateral_params(hunks_each_one);
 	git_blame_hunks_each_set.AddFunction(hunks_each_one);
 
 	TableFunction hunks_each_two({LogicalType::VARCHAR, LogicalType::VARCHAR}, nullptr, GitBlameHunksEachBind,
-	                              GitBlameInitGlobal, GitBlameLocalInit);
+	                             GitBlameInitGlobal, GitBlameLocalInit);
 	hunks_each_two.in_out_function = GitBlameHunksEachFunction;
 	declare_lateral_params(hunks_each_two);
 	git_blame_hunks_each_set.AddFunction(hunks_each_two);
@@ -788,13 +786,13 @@ void RegisterGitBlameFunction(ExtensionLoader &loader) {
 
 	TableFunctionSet git_blame_each_set("git_blame_each");
 	TableFunction blame_each_one({LogicalType::VARCHAR}, nullptr, GitBlameEachBind, GitBlameInitGlobal,
-	                              GitBlameLocalInit);
+	                             GitBlameLocalInit);
 	blame_each_one.in_out_function = GitBlameEachFunction;
 	declare_lateral_params(blame_each_one);
 	git_blame_each_set.AddFunction(blame_each_one);
 
 	TableFunction blame_each_two({LogicalType::VARCHAR, LogicalType::VARCHAR}, nullptr, GitBlameEachBind,
-	                              GitBlameInitGlobal, GitBlameLocalInit);
+	                             GitBlameInitGlobal, GitBlameLocalInit);
 	blame_each_two.in_out_function = GitBlameEachFunction;
 	declare_lateral_params(blame_each_two);
 	git_blame_each_set.AddFunction(blame_each_two);

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -25,10 +25,44 @@ static string ExtractFileExtension(const string &path) {
 	return path.substr(dot_pos);
 }
 
-static string OidToHex(const git_oid *oid) {
+static string oid_to_hex(const git_oid *oid) {
 	char hex[GIT_OID_HEXSZ + 1];
 	git_oid_tostr(hex, sizeof(hex), oid);
 	return string(hex);
+}
+
+// Simple UTF-8 validation to prevent DuckDB VARCHAR verification crashes on
+// non-UTF-8 text files. Mirrors git_read.cpp's IsValidUTF8 — duplicated here
+// rather than extracted until a third caller appears.
+static bool IsValidUTF8(const char *data, size_t length) {
+	const unsigned char *bytes = reinterpret_cast<const unsigned char *>(data);
+	for (size_t i = 0; i < length;) {
+		unsigned char byte = bytes[i];
+		if (byte <= 0x7F) {
+			i++;
+			continue;
+		}
+		int num_bytes = 0;
+		if ((byte & 0xE0) == 0xC0) {
+			num_bytes = 2;
+		} else if ((byte & 0xF0) == 0xE0) {
+			num_bytes = 3;
+		} else if ((byte & 0xF8) == 0xF0) {
+			num_bytes = 4;
+		} else {
+			return false;
+		}
+		if (i + num_bytes > length) {
+			return false;
+		}
+		for (int j = 1; j < num_bytes; j++) {
+			if ((bytes[i + j] & 0xC0) != 0x80) {
+				return false;
+			}
+		}
+		i += num_bytes;
+	}
+	return true;
 }
 
 //===--------------------------------------------------------------------===//
@@ -109,23 +143,32 @@ static bool LoadFileLines(git_repository *repo, git_commit *commit, const string
 	if (!is_binary) {
 		const char *data = static_cast<const char *>(git_blob_rawcontent(blob));
 		size_t size = static_cast<size_t>(git_blob_rawsize(blob));
-		size_t start = 0;
-		for (size_t i = 0; i < size; i++) {
-			if (data[i] == '\n') {
-				size_t end = i;
+
+		// Validate the whole blob as UTF-8 before splitting. DuckDB VARCHAR
+		// requires valid UTF-8; latin-1 and other 8-bit encodings would trip
+		// verification assertions. Mark the file as binary if validation fails
+		// so callers emit NULL line_content rather than garbage.
+		if (!IsValidUTF8(data, size)) {
+			is_binary = true;
+		} else {
+			size_t start = 0;
+			for (size_t i = 0; i < size; i++) {
+				if (data[i] == '\n') {
+					size_t end = i;
+					if (end > start && data[end - 1] == '\r') {
+						end--;
+					}
+					lines.emplace_back(data + start, end - start);
+					start = i + 1;
+				}
+			}
+			if (start < size) {
+				size_t end = size;
 				if (end > start && data[end - 1] == '\r') {
 					end--;
 				}
 				lines.emplace_back(data + start, end - start);
-				start = i + 1;
 			}
-		}
-		if (start < size) {
-			size_t end = size;
-			if (end > start && data[end - 1] == '\r') {
-				end--;
-			}
-			lines.emplace_back(data + start, end - start);
 		}
 	}
 
@@ -207,8 +250,8 @@ static void CollectBlameRows(git_repository *repo, const string &repo_path, cons
 			continue;
 		}
 
-		string commit_hash = OidToHex(&hunk->final_commit_id);
-		string orig_commit_hash = OidToHex(&hunk->orig_commit_id);
+		string commit_hash = oid_to_hex(&hunk->final_commit_id);
+		string orig_commit_hash = oid_to_hex(&hunk->orig_commit_id);
 		string author_name = hunk->final_signature && hunk->final_signature->name ? hunk->final_signature->name : "";
 		string author_email = hunk->final_signature && hunk->final_signature->email ? hunk->final_signature->email : "";
 		timestamp_t author_date = timestamp_t(0);
@@ -328,26 +371,13 @@ struct GitBlameLocalState : public LocalTableFunctionState {
 // git_blame_hunks static bind + exec
 //===--------------------------------------------------------------------===//
 
-// Raise if min_line/max_line are out of range. Internally, 0 means "unset"
-// (GIT_BLAME_OPTIONS_INIT defaults); the user-facing minimum is 1.
-static void ValidateBlameOptions(const GitBlameOptions &opts, const char *func_name) {
-	if (opts.min_line < 0) {
-		throw BinderException("%s: min_line must be >= 1", func_name);
-	}
-	if (opts.max_line < 0) {
-		throw BinderException("%s: max_line must be >= 1", func_name);
-	}
-	if (opts.min_line > 0 && opts.max_line > 0 && opts.min_line > opts.max_line) {
-		throw BinderException("%s: min_line (%lld) must be <= max_line (%lld)", func_name, (long long)opts.min_line,
-		                      (long long)opts.max_line);
-	}
-}
-
-// Extract the named parameters shared by every git_blame* static form.
-// Mutates `bind_data` and returns the overridden repo_path/revision for the
-// caller to apply *after* initial positional parsing.
+// Extract the named parameters shared by every git_blame* form (static and
+// LATERAL). Mutates `bind_data` and returns the overridden repo_path/revision
+// for the caller to apply *after* initial positional parsing. `func_name` is
+// the calling function (used in error messages so `_each` variants report
+// correctly).
 static void ApplyBlameNamedParams(const TableFunctionBindInput &input, GitBlameBindData &bind_data,
-                                  string &override_repo_path, string &override_revision) {
+                                  string &override_repo_path, string &override_revision, const char *func_name) {
 	for (const auto &kv : input.named_parameters) {
 		if (kv.first == "repo_path") {
 			override_repo_path = kv.second.GetValue<string>();
@@ -356,13 +386,13 @@ static void ApplyBlameNamedParams(const TableFunctionBindInput &input, GitBlameB
 		} else if (kv.first == "min_line") {
 			int64_t v = kv.second.GetValue<int64_t>();
 			if (v <= 0) {
-				throw BinderException("git_blame: min_line must be >= 1");
+				throw BinderException("%s: min_line must be >= 1", func_name);
 			}
 			bind_data.opts.min_line = v;
 		} else if (kv.first == "max_line") {
 			int64_t v = kv.second.GetValue<int64_t>();
 			if (v <= 0) {
-				throw BinderException("git_blame: max_line must be >= 1");
+				throw BinderException("%s: max_line must be >= 1", func_name);
 			}
 			bind_data.opts.max_line = v;
 		} else if (kv.first == "ignore_whitespace") {
@@ -372,6 +402,11 @@ static void ApplyBlameNamedParams(const TableFunctionBindInput &input, GitBlameB
 		} else if (kv.first == "first_parent") {
 			bind_data.opts.first_parent = kv.second.GetValue<bool>();
 		}
+	}
+	if (bind_data.opts.min_line > 0 && bind_data.opts.max_line > 0 &&
+	    bind_data.opts.min_line > bind_data.opts.max_line) {
+		throw BinderException("%s: min_line (%lld) must be <= max_line (%lld)", func_name,
+		                      (long long)bind_data.opts.min_line, (long long)bind_data.opts.max_line);
 	}
 }
 
@@ -388,8 +423,7 @@ static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableF
 
 	string override_repo_path;
 	string override_revision;
-	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
-	ValidateBlameOptions(bind_data->opts, "git_blame_hunks");
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision, "git_blame_hunks");
 
 	string first_param = input.inputs[0].GetValue<string>();
 	string resolved_repo_path;
@@ -511,8 +545,7 @@ static unique_ptr<FunctionData> GitBlameBind(ClientContext &context, TableFuncti
 
 	string override_repo_path;
 	string override_revision;
-	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
-	ValidateBlameOptions(bind_data->opts, "git_blame");
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision, "git_blame");
 
 	string first_param = input.inputs[0].GetValue<string>();
 	string resolved_repo_path;
@@ -592,8 +625,8 @@ static unique_ptr<FunctionData> GitBlameLateralBind(ClientContext &context, Tabl
 
 	string override_repo_path; // ignored for LATERAL (runtime provides path)
 	string override_revision;
-	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
-	ValidateBlameOptions(bind_data->opts, per_line ? "git_blame_each" : "git_blame_hunks_each");
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision,
+	                      per_line ? "git_blame_each" : "git_blame_hunks_each");
 
 	if (!override_revision.empty()) {
 		bind_data->revision = override_revision;
@@ -634,6 +667,11 @@ static void ResolveLateralInput(const string &raw_input, const string &bind_revi
 	out_revision = row_revision.empty() ? bind_revision : row_revision;
 }
 
+// Shared in/out exec for git_blame_each and git_blame_hunks_each. Per-row
+// failures (unparseable URI, repo open failure, blame computation failure) are
+// silently skipped rather than raised — matches the behavior of git_read_each
+// and git_diff_tree_each so that a single bad row in a LATERAL driver query
+// does not abort the whole join.
 static OperatorResultType GitBlameEachImpl(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
                                            DataChunk &output, bool per_line) {
 	auto &state = data_p.local_state->Cast<GitBlameLocalState>();

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -722,6 +722,17 @@ static OperatorResultType GitBlameHunksEachFunction(ExecutionContext &context, T
 	return GitBlameEachImpl(context, data_p, input, output, /*per_line=*/false);
 }
 
+static unique_ptr<FunctionData> GitBlameEachBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	DefineBlameSchema(return_types, names);
+	return GitBlameLateralBind(context, input, /*per_line=*/true);
+}
+
+static OperatorResultType GitBlameEachFunction(ExecutionContext &context, TableFunctionInput &data_p,
+                                                DataChunk &input, DataChunk &output) {
+	return GitBlameEachImpl(context, data_p, input, output, /*per_line=*/true);
+}
+
 //===--------------------------------------------------------------------===//
 // Registration
 //===--------------------------------------------------------------------===//
@@ -774,6 +785,21 @@ void RegisterGitBlameFunction(ExtensionLoader &loader) {
 	git_blame_hunks_each_set.AddFunction(hunks_each_two);
 
 	loader.RegisterFunction(git_blame_hunks_each_set);
+
+	TableFunctionSet git_blame_each_set("git_blame_each");
+	TableFunction blame_each_one({LogicalType::VARCHAR}, nullptr, GitBlameEachBind, GitBlameInitGlobal,
+	                              GitBlameLocalInit);
+	blame_each_one.in_out_function = GitBlameEachFunction;
+	declare_lateral_params(blame_each_one);
+	git_blame_each_set.AddFunction(blame_each_one);
+
+	TableFunction blame_each_two({LogicalType::VARCHAR, LogicalType::VARCHAR}, nullptr, GitBlameEachBind,
+	                              GitBlameInitGlobal, GitBlameLocalInit);
+	blame_each_two.in_out_function = GitBlameEachFunction;
+	declare_lateral_params(blame_each_two);
+	git_blame_each_set.AddFunction(blame_each_two);
+
+	loader.RegisterFunction(git_blame_each_set);
 }
 
 } // namespace duckdb

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -13,9 +13,487 @@
 
 namespace duckdb {
 
+//===--------------------------------------------------------------------===//
+// Helpers
+//===--------------------------------------------------------------------===//
+
+static string ExtractFileExtension(const string &path) {
+	size_t dot_pos = path.find_last_of('.');
+	if (dot_pos == string::npos || dot_pos == path.length() - 1) {
+		return "";
+	}
+	return path.substr(dot_pos);
+}
+
+static string OidToHex(const git_oid *oid) {
+	char hex[GIT_OID_HEXSZ + 1];
+	git_oid_tostr(hex, sizeof(hex), oid);
+	return string(hex);
+}
+
+//===--------------------------------------------------------------------===//
+// GitBlameRow — covers both per-line and per-hunk output shapes.
+//===--------------------------------------------------------------------===//
+
+struct GitBlameRow {
+	// Identity (populated by caller, not CollectBlameRows)
+	string repo_path;
+	string file_path;
+	string file_ext;
+	string revision;
+
+	// Per-line fields (git_blame)
+	int64_t line_number = 0;
+	string line_content;
+	bool line_content_is_null = false;
+
+	// Per-hunk fields (git_blame_hunks)
+	int64_t start_line = 0;
+	int64_t line_count = 0;
+	int64_t orig_start_line = 0;
+
+	// Shared fields
+	string commit_hash;
+	string author_name;
+	string author_email;
+	timestamp_t author_date = timestamp_t(0);
+	string orig_commit_hash;
+	string orig_path;
+	int64_t orig_line_number = 0;
+	bool boundary = false;
+};
+
+//===--------------------------------------------------------------------===//
+// GitBlameOptions — mirror of the blame-related named parameters.
+//===--------------------------------------------------------------------===//
+
+struct GitBlameOptions {
+	int64_t min_line = 0; // 0 means "no lower bound"
+	int64_t max_line = 0; // 0 means "no upper bound"
+	bool ignore_whitespace = false;
+	bool use_mailmap = false;
+	bool first_parent = false;
+};
+
+//===--------------------------------------------------------------------===//
+// Blame core
+//===--------------------------------------------------------------------===//
+
+// Loads the blob for `file_path` at `commit` and splits it into lines
+// (strips trailing `\r`). Returns false if the blob is binary; `lines` is
+// left empty in that case.
+static bool LoadFileLines(git_repository *repo, git_commit *commit, const string &file_path, vector<string> &lines) {
+	git_tree *tree = nullptr;
+	int error = git_commit_tree(&tree, commit);
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw IOException("git_blame: failed to get commit tree: %s", e ? e->message : "unknown error");
+	}
+
+	git_tree_entry *entry = nullptr;
+	error = git_tree_entry_bypath(&entry, tree, file_path.c_str());
+	if (error != 0) {
+		git_tree_free(tree);
+		throw IOException("git_blame: file not found '%s' at revision", file_path);
+	}
+
+	git_blob *blob = nullptr;
+	error = git_blob_lookup(&blob, repo, git_tree_entry_id(entry));
+	if (error != 0) {
+		git_tree_entry_free(entry);
+		git_tree_free(tree);
+		throw IOException("git_blame: failed to load blob for '%s'", file_path);
+	}
+
+	bool is_binary = git_blob_is_binary(blob) != 0;
+	if (!is_binary) {
+		const char *data = static_cast<const char *>(git_blob_rawcontent(blob));
+		size_t size = static_cast<size_t>(git_blob_rawsize(blob));
+		size_t start = 0;
+		for (size_t i = 0; i < size; i++) {
+			if (data[i] == '\n') {
+				size_t end = i;
+				if (end > start && data[end - 1] == '\r') {
+					end--;
+				}
+				lines.emplace_back(data + start, end - start);
+				start = i + 1;
+			}
+		}
+		if (start < size) {
+			size_t end = size;
+			if (end > start && data[end - 1] == '\r') {
+				end--;
+			}
+			lines.emplace_back(data + start, end - start);
+		}
+	}
+
+	git_blob_free(blob);
+	git_tree_entry_free(entry);
+	git_tree_free(tree);
+	return !is_binary;
+}
+
+// Computes blame rows for (repo, file_path) at `revision`. If `per_line` is
+// true, emits one row per line with `line_content`; otherwise emits one row
+// per hunk with `start_line`/`line_count`.
+static void CollectBlameRows(git_repository *repo, const string &repo_path, const string &file_path,
+                             const string &revision, const GitBlameOptions &opts, bool per_line,
+                             vector<GitBlameRow> &rows) {
+	git_object *rev_obj = nullptr;
+	int error = git_revparse_single(&rev_obj, repo, revision.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw IOException("git_blame: unable to resolve revision '%s': %s", revision, e ? e->message : "unknown error");
+	}
+
+	git_commit *commit = nullptr;
+	error = git_object_peel(reinterpret_cast<git_object **>(&commit), rev_obj, GIT_OBJECT_COMMIT);
+	if (error != 0) {
+		git_object_free(rev_obj);
+		throw IOException("git_blame: revision '%s' does not resolve to a commit", revision);
+	}
+
+	// Build blame options.
+	git_blame_options blame_opts = GIT_BLAME_OPTIONS_INIT;
+	git_oid_cpy(&blame_opts.newest_commit, git_commit_id(commit));
+	if (opts.min_line > 0) {
+		blame_opts.min_line = static_cast<size_t>(opts.min_line);
+	}
+	if (opts.max_line > 0) {
+		blame_opts.max_line = static_cast<size_t>(opts.max_line);
+	}
+	uint32_t flags = 0;
+	if (opts.ignore_whitespace) {
+		flags |= GIT_BLAME_IGNORE_WHITESPACE;
+	}
+	if (opts.use_mailmap) {
+		flags |= GIT_BLAME_USE_MAILMAP;
+	}
+	if (opts.first_parent) {
+		flags |= GIT_BLAME_FIRST_PARENT;
+	}
+	blame_opts.flags = flags;
+
+	git_blame *blame = nullptr;
+	error = git_blame_file(&blame, repo, file_path.c_str(), &blame_opts);
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		git_commit_free(commit);
+		git_object_free(rev_obj);
+		throw IOException("git_blame: blame failed for '%s': %s", file_path, e ? e->message : "unknown error");
+	}
+
+	// Load file lines if we need line_content.
+	vector<string> file_lines;
+	bool have_text = false;
+	if (per_line) {
+		try {
+			have_text = LoadFileLines(repo, commit, file_path, file_lines);
+		} catch (...) {
+			git_blame_free(blame);
+			git_commit_free(commit);
+			git_object_free(rev_obj);
+			throw;
+		}
+	}
+
+	string file_ext = ExtractFileExtension(file_path);
+	uint32_t hunk_count = git_blame_get_hunk_count(blame);
+	for (uint32_t i = 0; i < hunk_count; i++) {
+		const git_blame_hunk *hunk = git_blame_get_hunk_byindex(blame, i);
+		if (!hunk) {
+			continue;
+		}
+
+		string commit_hash = OidToHex(&hunk->final_commit_id);
+		string orig_commit_hash = OidToHex(&hunk->orig_commit_id);
+		string author_name = hunk->final_signature && hunk->final_signature->name ? hunk->final_signature->name : "";
+		string author_email =
+		    hunk->final_signature && hunk->final_signature->email ? hunk->final_signature->email : "";
+		timestamp_t author_date = timestamp_t(0);
+		if (hunk->final_signature) {
+			// libgit2 git_time is seconds since epoch (UTC).
+			author_date = Timestamp::FromEpochSeconds(hunk->final_signature->when.time);
+		}
+		string orig_path = hunk->orig_path ? string(hunk->orig_path) : file_path;
+		bool boundary = hunk->boundary != 0;
+
+		if (per_line) {
+			for (size_t offset = 0; offset < hunk->lines_in_hunk; offset++) {
+				int64_t line_no = static_cast<int64_t>(hunk->final_start_line_number + offset);
+				GitBlameRow row;
+				row.repo_path = repo_path;
+				row.file_path = file_path;
+				row.file_ext = file_ext;
+				row.revision = revision;
+				row.line_number = line_no;
+				if (have_text && line_no >= 1 && static_cast<size_t>(line_no) <= file_lines.size()) {
+					row.line_content = file_lines[line_no - 1];
+					row.line_content_is_null = false;
+				} else {
+					row.line_content_is_null = true;
+				}
+				row.commit_hash = commit_hash;
+				row.author_name = author_name;
+				row.author_email = author_email;
+				row.author_date = author_date;
+				row.orig_commit_hash = orig_commit_hash;
+				row.orig_path = orig_path;
+				row.orig_line_number = static_cast<int64_t>(hunk->orig_start_line_number + offset);
+				row.boundary = boundary;
+				rows.push_back(std::move(row));
+			}
+		} else {
+			GitBlameRow row;
+			row.repo_path = repo_path;
+			row.file_path = file_path;
+			row.file_ext = file_ext;
+			row.revision = revision;
+			row.start_line = static_cast<int64_t>(hunk->final_start_line_number);
+			row.line_count = static_cast<int64_t>(hunk->lines_in_hunk);
+			row.orig_start_line = static_cast<int64_t>(hunk->orig_start_line_number);
+			row.commit_hash = commit_hash;
+			row.author_name = author_name;
+			row.author_email = author_email;
+			row.author_date = author_date;
+			row.orig_commit_hash = orig_commit_hash;
+			row.orig_path = orig_path;
+			row.boundary = boundary;
+			rows.push_back(std::move(row));
+		}
+	}
+
+	git_blame_free(blame);
+	git_commit_free(commit);
+	git_object_free(rev_obj);
+}
+
+//===--------------------------------------------------------------------===//
+// Schemas
+//===--------------------------------------------------------------------===//
+
+static void DefineHunksSchema(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types = {LogicalType::VARCHAR,   LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::BIGINT,    LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::VARCHAR,   LogicalType::TIMESTAMP, LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::BOOLEAN};
+	names = {"repo_path",        "file_path",   "file_ext",         "revision",     "start_line",
+	         "line_count",       "commit_hash", "author_name",      "author_email", "author_date",
+	         "orig_commit_hash", "orig_path",   "orig_start_line",  "boundary"};
+}
+
+static void OutputHunkRow(DataChunk &output, const GitBlameRow &row, idx_t row_idx) {
+	output.SetValue(0, row_idx, Value(row.repo_path));
+	output.SetValue(1, row_idx, Value(row.file_path));
+	output.SetValue(2, row_idx, Value(row.file_ext));
+	output.SetValue(3, row_idx, Value(row.revision));
+	output.SetValue(4, row_idx, Value::BIGINT(row.start_line));
+	output.SetValue(5, row_idx, Value::BIGINT(row.line_count));
+	output.SetValue(6, row_idx, Value(row.commit_hash));
+	output.SetValue(7, row_idx, Value(row.author_name));
+	output.SetValue(8, row_idx, Value(row.author_email));
+	output.SetValue(9, row_idx, Value::TIMESTAMP(row.author_date));
+	output.SetValue(10, row_idx, Value(row.orig_commit_hash));
+	output.SetValue(11, row_idx, Value(row.orig_path));
+	output.SetValue(12, row_idx, Value::BIGINT(row.orig_start_line));
+	output.SetValue(13, row_idx, Value::BOOLEAN(row.boundary));
+}
+
+//===--------------------------------------------------------------------===//
+// Bind data — single struct used for all four functions.
+//===--------------------------------------------------------------------===//
+
+struct GitBlameBindData : public TableFunctionData {
+	string repo_path;
+	string file_path;
+	string revision;
+	GitBlameOptions opts;
+	bool per_line = true;  // false for *_hunks variants
+	bool is_lateral = false;
+	vector<GitBlameRow> rows; // Materialized at bind time for static forms
+};
+
+struct GitBlameLocalState : public LocalTableFunctionState {
+	idx_t current_index = 0;
+
+	// LATERAL processing state (unused in static form)
+	vector<GitBlameRow> current_rows;
+	idx_t current_input_row = 0;
+	idx_t current_output_row = 0;
+	bool initialized_row = false;
+};
+
+//===--------------------------------------------------------------------===//
+// git_blame_hunks static bind + exec
+//===--------------------------------------------------------------------===//
+
+static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types, vector<string> &names) {
+	DefineHunksSchema(return_types, names);
+
+	if (input.inputs.empty()) {
+		throw BinderException("git_blame_hunks requires a file path as its first argument");
+	}
+
+	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+	if (params.resolved_file_path.empty()) {
+		throw BinderException("git_blame_hunks: '%s' must refer to a file inside a git repository",
+		                      params.repo_path_or_uri);
+	}
+
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->repo_path = params.resolved_repo_path;
+	bind_data->file_path = params.resolved_file_path;
+	bind_data->revision = params.ref;
+	bind_data->per_line = false;
+
+	git_repository *repo = nullptr;
+	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw BinderException("git_blame_hunks: failed to open repository '%s': %s", bind_data->repo_path,
+		                      e ? e->message : "unknown error");
+	}
+
+	try {
+		CollectBlameRows(repo, bind_data->repo_path, bind_data->file_path, bind_data->revision, bind_data->opts,
+		                 /*per_line=*/false, bind_data->rows);
+	} catch (...) {
+		git_repository_free(repo);
+		throw;
+	}
+	git_repository_free(repo);
+
+	return std::move(bind_data);
+}
+
+static unique_ptr<GlobalTableFunctionState> GitBlameInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	return make_uniq<GlobalTableFunctionState>();
+}
+
+static unique_ptr<LocalTableFunctionState>
+GitBlameLocalInit(ExecutionContext &context, TableFunctionInitInput &input, GlobalTableFunctionState *global_state) {
+	return make_uniq<GitBlameLocalState>();
+}
+
+static void GitBlameHunksFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<GitBlameBindData>();
+	auto &local_state = data_p.local_state->Cast<GitBlameLocalState>();
+
+	idx_t output_count = 0;
+	while (local_state.current_index < bind_data.rows.size() && output_count < STANDARD_VECTOR_SIZE) {
+		OutputHunkRow(output, bind_data.rows[local_state.current_index], output_count);
+		local_state.current_index++;
+		output_count++;
+	}
+	output.SetCardinality(output_count);
+}
+
+//===--------------------------------------------------------------------===//
+// git_blame per-line schema + exec
+//===--------------------------------------------------------------------===//
+
+static void DefineBlameSchema(vector<LogicalType> &return_types, vector<string> &names) {
+	return_types = {LogicalType::VARCHAR,   LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::VARCHAR,   LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::VARCHAR,   LogicalType::TIMESTAMP, LogicalType::VARCHAR,  LogicalType::VARCHAR,
+	                LogicalType::BIGINT,    LogicalType::BOOLEAN};
+	names = {"repo_path",        "file_path",   "file_ext",         "revision",     "line_number",
+	         "line_content",     "commit_hash", "author_name",      "author_email", "author_date",
+	         "orig_commit_hash", "orig_path",   "orig_line_number", "boundary"};
+}
+
+static void OutputBlameRow(DataChunk &output, const GitBlameRow &row, idx_t row_idx) {
+	output.SetValue(0, row_idx, Value(row.repo_path));
+	output.SetValue(1, row_idx, Value(row.file_path));
+	output.SetValue(2, row_idx, Value(row.file_ext));
+	output.SetValue(3, row_idx, Value(row.revision));
+	output.SetValue(4, row_idx, Value::BIGINT(row.line_number));
+	if (row.line_content_is_null) {
+		output.SetValue(5, row_idx, Value());
+	} else {
+		output.SetValue(5, row_idx, Value(row.line_content));
+	}
+	output.SetValue(6, row_idx, Value(row.commit_hash));
+	output.SetValue(7, row_idx, Value(row.author_name));
+	output.SetValue(8, row_idx, Value(row.author_email));
+	output.SetValue(9, row_idx, Value::TIMESTAMP(row.author_date));
+	output.SetValue(10, row_idx, Value(row.orig_commit_hash));
+	output.SetValue(11, row_idx, Value(row.orig_path));
+	output.SetValue(12, row_idx, Value::BIGINT(row.orig_line_number));
+	output.SetValue(13, row_idx, Value::BOOLEAN(row.boundary));
+}
+
+static unique_ptr<FunctionData> GitBlameBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	DefineBlameSchema(return_types, names);
+
+	if (input.inputs.empty()) {
+		throw BinderException("git_blame requires a file path as its first argument");
+	}
+
+	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+	if (params.resolved_file_path.empty()) {
+		throw BinderException("git_blame: '%s' must refer to a file inside a git repository",
+		                      params.repo_path_or_uri);
+	}
+
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->repo_path = params.resolved_repo_path;
+	bind_data->file_path = params.resolved_file_path;
+	bind_data->revision = params.ref;
+	bind_data->per_line = true;
+
+	git_repository *repo = nullptr;
+	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
+	if (error != 0) {
+		const git_error *e = git_error_last();
+		throw BinderException("git_blame: failed to open repository '%s': %s", bind_data->repo_path,
+		                      e ? e->message : "unknown error");
+	}
+	try {
+		CollectBlameRows(repo, bind_data->repo_path, bind_data->file_path, bind_data->revision, bind_data->opts,
+		                 /*per_line=*/true, bind_data->rows);
+	} catch (...) {
+		git_repository_free(repo);
+		throw;
+	}
+	git_repository_free(repo);
+
+	return std::move(bind_data);
+}
+
+static void GitBlameFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<GitBlameBindData>();
+	auto &local_state = data_p.local_state->Cast<GitBlameLocalState>();
+
+	idx_t output_count = 0;
+	while (local_state.current_index < bind_data.rows.size() && output_count < STANDARD_VECTOR_SIZE) {
+		OutputBlameRow(output, bind_data.rows[local_state.current_index], output_count);
+		local_state.current_index++;
+		output_count++;
+	}
+	output.SetCardinality(output_count);
+}
+
+//===--------------------------------------------------------------------===//
+// Registration
+//===--------------------------------------------------------------------===//
+
 void RegisterGitBlameFunction(ExtensionLoader &loader) {
-	// Functions will be registered in later tasks.
-	(void)loader;
+	TableFunctionSet git_blame_hunks_set("git_blame_hunks");
+	TableFunction hunks_one({LogicalType::VARCHAR}, GitBlameHunksFunction, GitBlameHunksBind, GitBlameInitGlobal);
+	hunks_one.init_local = GitBlameLocalInit;
+	git_blame_hunks_set.AddFunction(hunks_one);
+	loader.RegisterFunction(git_blame_hunks_set);
+
+	TableFunctionSet git_blame_set("git_blame");
+	TableFunction blame_one({LogicalType::VARCHAR}, GitBlameFunction, GitBlameBind, GitBlameInitGlobal);
+	blame_one.init_local = GitBlameLocalInit;
+	git_blame_set.AddFunction(blame_one);
+	loader.RegisterFunction(git_blame_set);
 }
 
 } // namespace duckdb

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -329,6 +329,21 @@ struct GitBlameLocalState : public LocalTableFunctionState {
 // git_blame_hunks static bind + exec
 //===--------------------------------------------------------------------===//
 
+// Raise if min_line/max_line are out of range. Internally, 0 means "unset"
+// (GIT_BLAME_OPTIONS_INIT defaults); the user-facing minimum is 1.
+static void ValidateBlameOptions(const GitBlameOptions &opts, const char *func_name) {
+	if (opts.min_line < 0) {
+		throw BinderException("%s: min_line must be >= 1", func_name);
+	}
+	if (opts.max_line < 0) {
+		throw BinderException("%s: max_line must be >= 1", func_name);
+	}
+	if (opts.min_line > 0 && opts.max_line > 0 && opts.min_line > opts.max_line) {
+		throw BinderException("%s: min_line (%lld) must be <= max_line (%lld)", func_name,
+		                      (long long)opts.min_line, (long long)opts.max_line);
+	}
+}
+
 // Extract the named parameters shared by every git_blame* static form.
 // Mutates `bind_data` and returns the overridden repo_path/revision for the
 // caller to apply *after* initial positional parsing.
@@ -340,9 +355,17 @@ static void ApplyBlameNamedParams(const TableFunctionBindInput &input, GitBlameB
 		} else if (kv.first == "revision") {
 			override_revision = kv.second.GetValue<string>();
 		} else if (kv.first == "min_line") {
-			bind_data.opts.min_line = kv.second.GetValue<int64_t>();
+			int64_t v = kv.second.GetValue<int64_t>();
+			if (v <= 0) {
+				throw BinderException("git_blame: min_line must be >= 1");
+			}
+			bind_data.opts.min_line = v;
 		} else if (kv.first == "max_line") {
-			bind_data.opts.max_line = kv.second.GetValue<int64_t>();
+			int64_t v = kv.second.GetValue<int64_t>();
+			if (v <= 0) {
+				throw BinderException("git_blame: max_line must be >= 1");
+			}
+			bind_data.opts.max_line = v;
 		} else if (kv.first == "ignore_whitespace") {
 			bind_data.opts.ignore_whitespace = kv.second.GetValue<bool>();
 		} else if (kv.first == "use_mailmap") {
@@ -367,6 +390,7 @@ static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableF
 	string override_repo_path;
 	string override_revision;
 	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+	ValidateBlameOptions(bind_data->opts, "git_blame_hunks");
 
 	string first_param = input.inputs[0].GetValue<string>();
 	string resolved_repo_path;
@@ -489,6 +513,7 @@ static unique_ptr<FunctionData> GitBlameBind(ClientContext &context, TableFuncti
 	string override_repo_path;
 	string override_revision;
 	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+	ValidateBlameOptions(bind_data->opts, "git_blame");
 
 	string first_param = input.inputs[0].GetValue<string>();
 	string resolved_repo_path;

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -329,6 +329,30 @@ struct GitBlameLocalState : public LocalTableFunctionState {
 // git_blame_hunks static bind + exec
 //===--------------------------------------------------------------------===//
 
+// Extract the named parameters shared by every git_blame* static form.
+// Mutates `bind_data` and returns the overridden repo_path/revision for the
+// caller to apply *after* initial positional parsing.
+static void ApplyBlameNamedParams(const TableFunctionBindInput &input, GitBlameBindData &bind_data,
+                                  string &override_repo_path, string &override_revision) {
+	for (const auto &kv : input.named_parameters) {
+		if (kv.first == "repo_path") {
+			override_repo_path = kv.second.GetValue<string>();
+		} else if (kv.first == "revision") {
+			override_revision = kv.second.GetValue<string>();
+		} else if (kv.first == "min_line") {
+			bind_data.opts.min_line = kv.second.GetValue<int64_t>();
+		} else if (kv.first == "max_line") {
+			bind_data.opts.max_line = kv.second.GetValue<int64_t>();
+		} else if (kv.first == "ignore_whitespace") {
+			bind_data.opts.ignore_whitespace = kv.second.GetValue<bool>();
+		} else if (kv.first == "use_mailmap") {
+			bind_data.opts.use_mailmap = kv.second.GetValue<bool>();
+		} else if (kv.first == "first_parent") {
+			bind_data.opts.first_parent = kv.second.GetValue<bool>();
+		}
+	}
+}
+
 static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableFunctionBindInput &input,
                                                   vector<LogicalType> &return_types, vector<string> &names) {
 	DefineHunksSchema(return_types, names);
@@ -337,17 +361,43 @@ static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableF
 		throw BinderException("git_blame_hunks requires a file path as its first argument");
 	}
 
-	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
-	if (params.resolved_file_path.empty()) {
-		throw BinderException("git_blame_hunks: '%s' must refer to a file inside a git repository",
-		                      params.repo_path_or_uri);
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->per_line = false;
+
+	string override_repo_path;
+	string override_revision;
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+
+	string first_param = input.inputs[0].GetValue<string>();
+	string resolved_repo_path;
+	string resolved_file_path;
+	string resolved_revision;
+
+	if (!override_repo_path.empty()) {
+		// User provided repo_path explicitly; first positional is the file path within it.
+		string uri = "git://" + override_repo_path + "/" + first_param + "@HEAD";
+		auto ctx = GitContextManager::Instance().ProcessGitUri(uri, "HEAD");
+		resolved_repo_path = ctx.repo_path;
+		resolved_file_path = ctx.file_path;
+		resolved_revision = "HEAD";
+	} else {
+		auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+		if (params.resolved_file_path.empty()) {
+			throw BinderException("git_blame_hunks: '%s' must refer to a file inside a git repository",
+			                      params.repo_path_or_uri);
+		}
+		resolved_repo_path = params.resolved_repo_path;
+		resolved_file_path = params.resolved_file_path;
+		resolved_revision = params.ref;
 	}
 
-	auto bind_data = make_uniq<GitBlameBindData>();
-	bind_data->repo_path = params.resolved_repo_path;
-	bind_data->file_path = params.resolved_file_path;
-	bind_data->revision = params.ref;
-	bind_data->per_line = false;
+	if (!override_revision.empty()) {
+		resolved_revision = override_revision;
+	}
+
+	bind_data->repo_path = resolved_repo_path;
+	bind_data->file_path = resolved_file_path;
+	bind_data->revision = resolved_revision;
 
 	git_repository *repo = nullptr;
 	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
@@ -356,7 +406,6 @@ static unique_ptr<FunctionData> GitBlameHunksBind(ClientContext &context, TableF
 		throw BinderException("git_blame_hunks: failed to open repository '%s': %s", bind_data->repo_path,
 		                      e ? e->message : "unknown error");
 	}
-
 	try {
 		CollectBlameRows(repo, bind_data->repo_path, bind_data->file_path, bind_data->revision, bind_data->opts,
 		                 /*per_line=*/false, bind_data->rows);
@@ -434,17 +483,42 @@ static unique_ptr<FunctionData> GitBlameBind(ClientContext &context, TableFuncti
 		throw BinderException("git_blame requires a file path as its first argument");
 	}
 
-	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
-	if (params.resolved_file_path.empty()) {
-		throw BinderException("git_blame: '%s' must refer to a file inside a git repository",
-		                      params.repo_path_or_uri);
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->per_line = true;
+
+	string override_repo_path;
+	string override_revision;
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+
+	string first_param = input.inputs[0].GetValue<string>();
+	string resolved_repo_path;
+	string resolved_file_path;
+	string resolved_revision;
+
+	if (!override_repo_path.empty()) {
+		string uri = "git://" + override_repo_path + "/" + first_param + "@HEAD";
+		auto ctx = GitContextManager::Instance().ProcessGitUri(uri, "HEAD");
+		resolved_repo_path = ctx.repo_path;
+		resolved_file_path = ctx.file_path;
+		resolved_revision = "HEAD";
+	} else {
+		auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
+		if (params.resolved_file_path.empty()) {
+			throw BinderException("git_blame: '%s' must refer to a file inside a git repository",
+			                      params.repo_path_or_uri);
+		}
+		resolved_repo_path = params.resolved_repo_path;
+		resolved_file_path = params.resolved_file_path;
+		resolved_revision = params.ref;
 	}
 
-	auto bind_data = make_uniq<GitBlameBindData>();
-	bind_data->repo_path = params.resolved_repo_path;
-	bind_data->file_path = params.resolved_file_path;
-	bind_data->revision = params.ref;
-	bind_data->per_line = true;
+	if (!override_revision.empty()) {
+		resolved_revision = override_revision;
+	}
+
+	bind_data->repo_path = resolved_repo_path;
+	bind_data->file_path = resolved_file_path;
+	bind_data->revision = resolved_revision;
 
 	git_repository *repo = nullptr;
 	int error = git_repository_open(&repo, bind_data->repo_path.c_str());
@@ -483,15 +557,27 @@ static void GitBlameFunction(ClientContext &context, TableFunctionInput &data_p,
 //===--------------------------------------------------------------------===//
 
 void RegisterGitBlameFunction(ExtensionLoader &loader) {
+	auto declare_named_params = [](TableFunction &fn) {
+		fn.named_parameters["repo_path"] = LogicalType::VARCHAR;
+		fn.named_parameters["revision"] = LogicalType::VARCHAR;
+		fn.named_parameters["min_line"] = LogicalType::BIGINT;
+		fn.named_parameters["max_line"] = LogicalType::BIGINT;
+		fn.named_parameters["ignore_whitespace"] = LogicalType::BOOLEAN;
+		fn.named_parameters["use_mailmap"] = LogicalType::BOOLEAN;
+		fn.named_parameters["first_parent"] = LogicalType::BOOLEAN;
+	};
+
 	TableFunctionSet git_blame_hunks_set("git_blame_hunks");
 	TableFunction hunks_one({LogicalType::VARCHAR}, GitBlameHunksFunction, GitBlameHunksBind, GitBlameInitGlobal);
 	hunks_one.init_local = GitBlameLocalInit;
+	declare_named_params(hunks_one);
 	git_blame_hunks_set.AddFunction(hunks_one);
 	loader.RegisterFunction(git_blame_hunks_set);
 
 	TableFunctionSet git_blame_set("git_blame");
 	TableFunction blame_one({LogicalType::VARCHAR}, GitBlameFunction, GitBlameBind, GitBlameInitGlobal);
 	blame_one.init_local = GitBlameLocalInit;
+	declare_named_params(blame_one);
 	git_blame_set.AddFunction(blame_one);
 	loader.RegisterFunction(git_blame_set);
 }

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -578,6 +578,151 @@ static void GitBlameFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 //===--------------------------------------------------------------------===//
+// LATERAL variants
+//===--------------------------------------------------------------------===//
+
+// Shared bind for LATERAL forms: stores bind-time named parameters in bind
+// data; the runtime file path/URI and optional revision come from the input
+// DataChunk per row.
+static unique_ptr<FunctionData> GitBlameLateralBind(ClientContext &context, TableFunctionBindInput &input,
+                                                     bool per_line) {
+	auto bind_data = make_uniq<GitBlameBindData>();
+	bind_data->per_line = per_line;
+	bind_data->is_lateral = true;
+	bind_data->revision = "HEAD";
+
+	string override_repo_path; // ignored for LATERAL (runtime provides path)
+	string override_revision;
+	ApplyBlameNamedParams(input, *bind_data, override_repo_path, override_revision);
+	ValidateBlameOptions(bind_data->opts, per_line ? "git_blame_each" : "git_blame_hunks_each");
+
+	if (!override_revision.empty()) {
+		bind_data->revision = override_revision;
+	}
+	return std::move(bind_data);
+}
+
+static unique_ptr<FunctionData> GitBlameHunksEachBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	DefineHunksSchema(return_types, names);
+	return GitBlameLateralBind(context, input, /*per_line=*/false);
+}
+
+// Resolve a LATERAL input path (URI or plain path) + optional per-row revision
+// override into (repo_path, file_path, revision).
+static void ResolveLateralInput(const string &raw_input, const string &bind_revision, const string &row_revision,
+                                string &out_repo_path, string &out_file_path, string &out_revision) {
+	// If the input is a git:// URI, let GitContextManager parse it fully.
+	if (StringUtil::StartsWith(raw_input, "git://")) {
+		auto ctx = GitContextManager::Instance().ProcessGitUri(raw_input, "HEAD");
+		out_repo_path = ctx.repo_path;
+		out_file_path = ctx.file_path;
+		// URI @rev wins unless the caller passed an explicit row revision.
+		if (!row_revision.empty()) {
+			out_revision = row_revision;
+		} else if (!ctx.final_ref.empty() && ctx.final_ref != "HEAD") {
+			out_revision = ctx.final_ref;
+		} else {
+			out_revision = bind_revision;
+		}
+		return;
+	}
+
+	// Plain path — discover repo via GitContextManager.
+	auto ctx = GitContextManager::Instance().ProcessGitUri("git://" + raw_input + "@HEAD", "HEAD");
+	out_repo_path = ctx.repo_path;
+	out_file_path = ctx.file_path;
+	out_revision = row_revision.empty() ? bind_revision : row_revision;
+}
+
+static OperatorResultType GitBlameEachImpl(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+                                            DataChunk &output, bool per_line) {
+	auto &state = data_p.local_state->Cast<GitBlameLocalState>();
+	auto &bind_data = data_p.bind_data->Cast<GitBlameBindData>();
+
+	while (true) {
+		if (!state.initialized_row) {
+			if (state.current_input_row >= input.size()) {
+				state.current_input_row = 0;
+				state.initialized_row = false;
+				return OperatorResultType::NEED_MORE_INPUT;
+			}
+
+			input.Flatten();
+			if (input.ColumnCount() == 0 || FlatVector::IsNull(input.data[0], state.current_input_row)) {
+				state.current_input_row++;
+				continue;
+			}
+
+			auto file_vec = FlatVector::GetData<string_t>(input.data[0]);
+			string raw_input(file_vec[state.current_input_row].GetData(),
+			                 file_vec[state.current_input_row].GetSize());
+
+			string row_revision;
+			if (input.ColumnCount() > 1 && !FlatVector::IsNull(input.data[1], state.current_input_row)) {
+				auto rev_vec = FlatVector::GetData<string_t>(input.data[1]);
+				row_revision = string(rev_vec[state.current_input_row].GetData(),
+				                      rev_vec[state.current_input_row].GetSize());
+			}
+
+			string repo_path, file_path, revision;
+			try {
+				ResolveLateralInput(raw_input, bind_data.revision, row_revision, repo_path, file_path, revision);
+			} catch (...) {
+				state.current_input_row++;
+				continue;
+			}
+
+			state.current_rows.clear();
+			git_repository *repo = nullptr;
+			int error = git_repository_open(&repo, repo_path.c_str());
+			if (error != 0) {
+				state.current_input_row++;
+				continue;
+			}
+			try {
+				// Populate identity fields on each row via caller post-process below.
+				CollectBlameRows(repo, repo_path, file_path, revision, bind_data.opts, per_line, state.current_rows);
+			} catch (...) {
+				git_repository_free(repo);
+				state.current_input_row++;
+				continue;
+			}
+			git_repository_free(repo);
+
+			state.initialized_row = true;
+			state.current_output_row = 0;
+		}
+
+		idx_t output_count = 0;
+		while (output_count < STANDARD_VECTOR_SIZE && state.current_output_row < state.current_rows.size()) {
+			if (per_line) {
+				OutputBlameRow(output, state.current_rows[state.current_output_row], output_count);
+			} else {
+				OutputHunkRow(output, state.current_rows[state.current_output_row], output_count);
+			}
+			state.current_output_row++;
+			output_count++;
+		}
+		output.SetCardinality(output_count);
+
+		if (state.current_output_row >= state.current_rows.size()) {
+			state.current_input_row++;
+			state.initialized_row = false;
+		}
+
+		if (output_count > 0) {
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+	}
+}
+
+static OperatorResultType GitBlameHunksEachFunction(ExecutionContext &context, TableFunctionInput &data_p,
+                                                     DataChunk &input, DataChunk &output) {
+	return GitBlameEachImpl(context, data_p, input, output, /*per_line=*/false);
+}
+
+//===--------------------------------------------------------------------===//
 // Registration
 //===--------------------------------------------------------------------===//
 
@@ -605,6 +750,30 @@ void RegisterGitBlameFunction(ExtensionLoader &loader) {
 	declare_named_params(blame_one);
 	git_blame_set.AddFunction(blame_one);
 	loader.RegisterFunction(git_blame_set);
+
+	auto declare_lateral_params = [](TableFunction &fn) {
+		fn.named_parameters["revision"] = LogicalType::VARCHAR;
+		fn.named_parameters["min_line"] = LogicalType::BIGINT;
+		fn.named_parameters["max_line"] = LogicalType::BIGINT;
+		fn.named_parameters["ignore_whitespace"] = LogicalType::BOOLEAN;
+		fn.named_parameters["use_mailmap"] = LogicalType::BOOLEAN;
+		fn.named_parameters["first_parent"] = LogicalType::BOOLEAN;
+	};
+
+	TableFunctionSet git_blame_hunks_each_set("git_blame_hunks_each");
+	TableFunction hunks_each_one({LogicalType::VARCHAR}, nullptr, GitBlameHunksEachBind, GitBlameInitGlobal,
+	                              GitBlameLocalInit);
+	hunks_each_one.in_out_function = GitBlameHunksEachFunction;
+	declare_lateral_params(hunks_each_one);
+	git_blame_hunks_each_set.AddFunction(hunks_each_one);
+
+	TableFunction hunks_each_two({LogicalType::VARCHAR, LogicalType::VARCHAR}, nullptr, GitBlameHunksEachBind,
+	                              GitBlameInitGlobal, GitBlameLocalInit);
+	hunks_each_two.in_out_function = GitBlameHunksEachFunction;
+	declare_lateral_params(hunks_each_two);
+	git_blame_hunks_each_set.AddFunction(hunks_each_two);
+
+	loader.RegisterFunction(git_blame_hunks_each_set);
 }
 
 } // namespace duckdb

--- a/src/git_functions.cpp
+++ b/src/git_functions.cpp
@@ -29,6 +29,7 @@ void RegisterGitReadFunction(ExtensionLoader &loader);
 void RegisterGitUriFunction(ExtensionLoader &loader);
 void RegisterGitStatusFunction(ExtensionLoader &loader);
 void RegisterGitDiffTreeFunction(ExtensionLoader &loader);
+void RegisterGitBlameFunction(ExtensionLoader &loader);
 
 void RegisterGitFunctions(ExtensionLoader &loader) {
 	RegisterGitLogFunction(loader);
@@ -40,6 +41,7 @@ void RegisterGitFunctions(ExtensionLoader &loader) {
 	RegisterGitUriFunction(loader);
 	RegisterGitStatusFunction(loader);
 	RegisterGitDiffTreeFunction(loader);
+	RegisterGitBlameFunction(loader);
 }
 
 } // namespace duckdb

--- a/src/include/git_functions.hpp
+++ b/src/include/git_functions.hpp
@@ -333,6 +333,7 @@ void RegisterGitReadFunction(ExtensionLoader &loader);
 void RegisterGitUriFunction(ExtensionLoader &loader);
 void RegisterGitStatusFunction(ExtensionLoader &loader);
 void RegisterGitDiffTreeFunction(ExtensionLoader &loader);
+void RegisterGitBlameFunction(ExtensionLoader &loader);
 void RegisterGitFunctions(ExtensionLoader &loader);
 
 } // namespace duckdb

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -157,3 +157,13 @@ SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md',
                                 first_parent := true)
 ----
 2
+
+# git_blame_hunks_each via LATERAL over a values list
+query II
+SELECT v.f, COUNT(*) AS n_hunks
+FROM (VALUES ('test/tmp/main-repo/README.md')) AS v(f),
+     LATERAL git_blame_hunks_each(v.f) h
+GROUP BY v.f
+ORDER BY v.f
+----
+test/tmp/main-repo/README.md	2

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -33,3 +33,30 @@ ORDER BY start_line
 ----
 1	1	Test User
 2	1	Test User
+
+# git_blame per-line form
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md')
+----
+2
+
+# Line numbers and content for each row
+query III
+SELECT line_number, line_content, author_name
+FROM git_blame('test/tmp/main-repo/README.md')
+ORDER BY line_number
+----
+1	# Test Repository	Test User
+2	# Development features	Test User
+
+# line_number starts at 1
+query I
+SELECT MIN(line_number) FROM git_blame('test/tmp/main-repo/README.md')
+----
+1
+
+# commit_hash should be non-null for every row
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md') WHERE commit_hash IS NULL
+----
+0

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -75,3 +75,25 @@ query I
 SELECT COUNT(*) FROM git_blame_hunks('git://test/tmp/main-repo/README.md@HEAD')
 ----
 2
+
+# Explicit revision via named parameter
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md', revision := 'HEAD')
+----
+2
+
+# Explicit repo_path with file_path relative to it
+query II
+SELECT line_number, author_name
+FROM git_blame('README.md', repo_path := 'test/tmp/main-repo')
+ORDER BY line_number
+----
+1	Test User
+2	Test User
+
+# Both named params together
+query I
+SELECT COUNT(*)
+FROM git_blame_hunks('README.md', repo_path := 'test/tmp/main-repo', revision := 'HEAD')
+----
+2

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -228,3 +228,75 @@ SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame_hunks('test/tmp/main-repo
 WHERE column_name IN ('start_line', 'line_count')
 ----
 2
+
+# git_tree(...) driving LATERAL git_blame_each — the canonical pluckit-style
+# pattern: iterate every file in a commit, blame each. main-repo HEAD has 3
+# files (README.md + app.js + src/main.py = 4 lines total).
+query II
+SELECT COUNT(DISTINCT t.file_path) AS files, COUNT(*) AS lines
+FROM git_tree('git://test/tmp/main-repo@HEAD') t,
+     LATERAL git_blame_each(t.git_uri) b
+WHERE t.kind = 'file'
+----
+3	4
+
+# Same pattern with git_blame_hunks_each — one row per hunk, not per line.
+# README.md has 2 hunks (line-per-commit), app.js + main.py have 1 hunk each = 4.
+query I
+SELECT COUNT(*)
+FROM git_tree('git://test/tmp/main-repo@HEAD') t,
+     LATERAL git_blame_hunks_each(t.git_uri) h
+WHERE t.kind = 'file'
+----
+4
+
+# Sum of line_count across all hunks equals total file lines (4).
+query I
+SELECT SUM(h.line_count)
+FROM git_tree('git://test/tmp/main-repo@HEAD') t,
+     LATERAL git_blame_hunks_each(t.git_uri) h
+WHERE t.kind = 'file'
+----
+4
+
+# Multi-file LATERAL via VALUES: verify each file's rows are correctly grouped.
+query II
+SELECT v.f, COUNT(*) AS n_lines
+FROM (VALUES
+      ('test/tmp/main-repo/README.md'),
+      ('test/tmp/main-repo/app.js'),
+      ('test/tmp/main-repo/src/main.py')) AS v(f),
+     LATERAL git_blame_each(v.f) g
+GROUP BY v.f
+ORDER BY v.f
+----
+test/tmp/main-repo/README.md	2
+test/tmp/main-repo/app.js	1
+test/tmp/main-repo/src/main.py	1
+
+# file_path and file_ext propagate correctly through the LATERAL join.
+query III
+SELECT DISTINCT g.file_path, g.file_ext, g.author_name
+FROM (VALUES ('test/tmp/main-repo/src/main.py')) AS v(f),
+     LATERAL git_blame_each(v.f) g
+ORDER BY g.file_path
+----
+src/main.py	.py	Test User
+
+# Querying a subdirectory file via repo_path + relative path (sanity check
+# that the override_repo_path path survives subdirectory traversal).
+query II
+SELECT line_number, line_content
+FROM git_blame('src/main.py', repo_path := 'test/tmp/main-repo')
+ORDER BY line_number
+----
+1	print('hello world')
+
+# line_content is non-NULL for known text files (indirect verification that
+# the UTF-8 validation path doesn't wrongly mark clean ASCII as binary).
+query I
+SELECT COUNT(*)
+FROM git_blame('test/tmp/main-repo/README.md')
+WHERE line_content IS NULL
+----
+0

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -167,3 +167,23 @@ GROUP BY v.f
 ORDER BY v.f
 ----
 test/tmp/main-repo/README.md	2
+
+# git_blame_each: basic per-line via LATERAL
+query III
+SELECT v.f, g.line_number, g.author_name
+FROM (VALUES ('test/tmp/main-repo/README.md')) AS v(f),
+     LATERAL git_blame_each(v.f) g
+ORDER BY v.f, g.line_number
+----
+test/tmp/main-repo/README.md	1	Test User
+test/tmp/main-repo/README.md	2	Test User
+
+# git_blame_each with a per-row revision override (second LATERAL column)
+query II
+SELECT g.line_number, g.author_name
+FROM (VALUES ('test/tmp/main-repo/README.md', 'HEAD')) AS v(f, r),
+     LATERAL git_blame_each(v.f, v.r) g
+ORDER BY g.line_number
+----
+1	Test User
+2	Test User

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -1,0 +1,35 @@
+# name: test/sql/git_blame.test
+# description: Tests for git_blame and git_blame_hunks table functions (issue #18)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+statement ok
+PRAGMA enable_verification;
+
+# git_blame_hunks: basic single-positional form. The main-repo fixture's
+# README.md has 2 lines from 2 different commits, so we expect 2 hunks.
+query I
+SELECT COUNT(*) FROM git_blame_hunks('test/tmp/main-repo/README.md')
+----
+2
+
+# Hunk line counts must sum to the file's line count (2)
+query I
+SELECT SUM(line_count) FROM git_blame_hunks('test/tmp/main-repo/README.md')
+----
+2
+
+# First hunk covers line 1 and the author matches the fixture
+query III
+SELECT start_line, line_count, author_name
+FROM git_blame_hunks('test/tmp/main-repo/README.md')
+ORDER BY start_line
+----
+1	1	Test User
+2	1	Test User

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -60,3 +60,18 @@ query I
 SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md') WHERE commit_hash IS NULL
 ----
 0
+
+# git:// URI form should produce the same result as the plain path form
+query II
+SELECT line_number, author_name
+FROM git_blame('git://test/tmp/main-repo/README.md@HEAD')
+ORDER BY line_number
+----
+1	Test User
+2	Test User
+
+# git_blame_hunks URI form
+query I
+SELECT COUNT(*) FROM git_blame_hunks('git://test/tmp/main-repo/README.md@HEAD')
+----
+2

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -97,3 +97,36 @@ SELECT COUNT(*)
 FROM git_blame_hunks('README.md', repo_path := 'test/tmp/main-repo', revision := 'HEAD')
 ----
 2
+
+# min_line restricts to the first line only
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md', min_line := 1, max_line := 1)
+----
+1
+
+query II
+SELECT line_number, line_content FROM git_blame('test/tmp/main-repo/README.md', min_line := 1, max_line := 1)
+----
+1	# Test Repository
+
+# max_line alone restricts to line <= 2 (all rows)
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md', max_line := 2)
+----
+2
+
+# min_line alone starts blame at line 2
+query II
+SELECT line_number, line_content FROM git_blame('test/tmp/main-repo/README.md', min_line := 2)
+----
+2	# Development features
+
+# Invalid range: min_line > max_line
+statement error
+SELECT * FROM git_blame('test/tmp/main-repo/README.md', min_line := 5, max_line := 1)
+----
+
+# Invalid: min_line = 0 (must be >= 1)
+statement error
+SELECT * FROM git_blame('test/tmp/main-repo/README.md', min_line := 0)
+----

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -130,3 +130,30 @@ SELECT * FROM git_blame('test/tmp/main-repo/README.md', min_line := 5, max_line 
 statement error
 SELECT * FROM git_blame('test/tmp/main-repo/README.md', min_line := 0)
 ----
+
+# ignore_whitespace smoke test
+query I
+SELECT COUNT(*) >= 0 FROM git_blame('test/tmp/main-repo/README.md', ignore_whitespace := true)
+----
+true
+
+# use_mailmap smoke test
+query I
+SELECT COUNT(*) >= 0 FROM git_blame('test/tmp/main-repo/README.md', use_mailmap := true)
+----
+true
+
+# first_parent smoke test
+query I
+SELECT COUNT(*) >= 0 FROM git_blame('test/tmp/main-repo/README.md', first_parent := true)
+----
+true
+
+# All flags at once
+query I
+SELECT COUNT(*) FROM git_blame('test/tmp/main-repo/README.md',
+                                ignore_whitespace := true,
+                                use_mailmap := true,
+                                first_parent := true)
+----
+2

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -187,3 +187,18 @@ ORDER BY g.line_number
 ----
 1	Test User
 2	Test User
+
+# Nonexistent file in an existing repo
+statement error
+SELECT * FROM git_blame('does-not-exist.md', repo_path := 'test/tmp/main-repo')
+----
+
+# Nonexistent revision
+statement error
+SELECT * FROM git_blame('test/tmp/main-repo/README.md', revision := 'this-ref-does-not-exist')
+----
+
+# Nonexistent repository path
+statement error
+SELECT * FROM git_blame('README.md', repo_path := '/nonexistent/repo/path')
+----

--- a/test/sql/git_blame.test
+++ b/test/sql/git_blame.test
@@ -202,3 +202,29 @@ SELECT * FROM git_blame('test/tmp/main-repo/README.md', revision := 'this-ref-do
 statement error
 SELECT * FROM git_blame('README.md', repo_path := '/nonexistent/repo/path')
 ----
+
+# git_blame per-line column count = 14
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame('test/tmp/main-repo/README.md'))
+----
+14
+
+# git_blame_hunks column count = 14
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame_hunks('test/tmp/main-repo/README.md'))
+----
+14
+
+# git_blame has line_number and line_content columns
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame('test/tmp/main-repo/README.md'))
+WHERE column_name IN ('line_number', 'line_content')
+----
+2
+
+# git_blame_hunks has start_line and line_count columns
+query I
+SELECT COUNT(*) FROM (DESCRIBE SELECT * FROM git_blame_hunks('test/tmp/main-repo/README.md'))
+WHERE column_name IN ('start_line', 'line_count')
+----
+2


### PR DESCRIPTION
## Summary

- New `git_blame` and `git_blame_hunks` table functions (plus `_each` LATERAL variants) wrapping libgit2's `git_blame_file` for line-level authorship lookup.
- `git_blame` returns one row per line with `line_content`; `git_blame_hunks` returns one row per libgit2 hunk (cheaper when `line_content` isn't needed).
- Named parameters: `repo_path`, `revision`, `min_line`, `max_line`, `ignore_whitespace`, `use_mailmap`, `first_parent`. `min_line`/`max_line` are passed directly to libgit2, so restricting blame to an AST node's line range is proportional to the requested span rather than the whole file — the target use case called out in the issue for downstream pluckit.

## Design & plan

- Spec: `docs/superpowers/specs/2026-04-11-git-blame-design.md`
- Plan: `docs/superpowers/plans/2026-04-11-git-blame.md`
- User-facing docs: `docs/reference/git_blame.md`

## Test plan

- [ ] CI builds the extension cleanly
- [ ] `test/sql/git_blame.test` passes end-to-end:
  - [ ] `git_blame_hunks` basic single-positional form (hunks count, line_count sum, per-hunk authors)
  - [ ] `git_blame` per-line form (content + author per line)
  - [ ] `git://` URI form for both shapes
  - [ ] `repo_path` / `revision` named parameters (explicit and combined)
  - [ ] `min_line` / `max_line` including error paths (min > max, min_line = 0)
  - [ ] Smoke tests for `ignore_whitespace`, `use_mailmap`, `first_parent`
  - [ ] `git_blame_each` and `git_blame_hunks_each` LATERAL variants
  - [ ] LATERAL per-row revision override
  - [ ] Error paths: nonexistent file, nonexistent revision, bad repo_path
  - [ ] Schema pin (14 columns each for per-line and hunks)

## Notes

- Non-UTF-8 text files are treated as binary (NULL `line_content`) to prevent DuckDB VARCHAR verification crashes; mirrors `git_read.cpp`'s approach.
- LATERAL variants silently skip per-row failures (unparseable URI, bad repo, bad revision) — consistent with `git_read_each` / `git_diff_tree_each`.
- libgit2's rename-tracking flags (`GIT_BLAME_TRACK_COPIES_*`) are deliberately not exposed since upstream libgit2 leaves them unimplemented; `orig_path` is still surfaced from `git_blame_hunk` but will almost always equal `file_path` until that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)