### PR TITLE
ci: v1.5.4 toolchain + re-enable Windows; fix fixture extraction on Windows

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -24,7 +24,7 @@ jobs:
       # windows_amd64(_mingw): excluded for this repo -- the git:// LFS object
       # transport this extension is built around is unsupported on Windows, so
       # Windows builds/tests are not maintained here.
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
 
   duckdb-stable-build:
     name: Build extension binaries
@@ -38,7 +38,7 @@ jobs:
       extension_name: duck_tails
       # See note above: exclude wasm (no libgit2 for wasm) and Windows
       # (git:// LFS transport unsupported on Windows).
-      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_mingw'
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
 
   code-quality-check:
     name: Code Quality Check

--- a/test/fixtures/setup_fixtures.sh
+++ b/test/fixtures/setup_fixtures.sh
@@ -3,7 +3,7 @@
 # This script extracts compressed git repository fixtures to /tmp for testing,
 # ensuring predictable and isolated test environments.
 
-set -e
+set -eo pipefail
 
 FIXTURES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMP_DIR=""
@@ -55,7 +55,12 @@ setup_fixtures() {
         
         echo "Extracting $fixture_file..."
         cd "$TEMP_DIR"
-        tar -xzf "$fixture_path"
+        # Decompress via a pipe rather than `tar -xzf <path>`: on Windows the
+        # fixture path carries a drive letter (D:\...), which GNU tar misreads
+        # as a remote host ("Cannot connect to D: resolve failed"). Piping keeps
+        # the colon-bearing path away from tar's -f parsing, and unlike
+        # `--force-local` it stays portable to macOS bsdtar.
+        gzip -dc "$fixture_path" | tar -xf -
         
         # Store repository info
         repo_name="${fixture_file%.tar.gz}"


### PR DESCRIPTION
## What

1. Point the stable build + code-quality jobs at v1.5-variegata / v1.5.4 (submodules already tracked it; the workflow still pinned v1.5.3) and **drop the Windows exclusion** — v1.5.4 carries the vendored-fmt MSVC fix that was the original blocker.
2. **Fix test-fixture extraction on Windows**: GNU tar misreads the drive-letter in the archive path (`D:\...`) as a remote host. Decompress via a gzip pipe so the path never reaches tar's `-f` parsing (portable to bsdtar, unlike `--force-local`).

## Why it matters

The fixture bug means the git-function tests have **never run on Windows** — relevant context for #28. With this PR, CI is fully green on `windows_amd64` and `windows_amd64_mingw` including the test suite: run 31149250120.

libgit2 (the risk flagged for Windows) builds fine via vcpkg — the original exclusion reason (fmt/MSVC) was the only blocker, and it's gone.

## Next

Release + community-extensions descriptor update to drop the Windows exclusion, which resolves the install-404 (#30). The #28 git_log behavior report stays open — CI fixtures don't yet exercise the reporter's exact argument shapes (absolute Windows paths, cwd-relative `.`); follow-up tests planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32kWhs96dz7VnR9dYYAJy