### PR TITLE
fix: honour the repo_path named parameter (#36)

### DIFF
--- a/src/git_read.cpp
+++ b/src/git_read.cpp
@@ -75,49 +75,6 @@ static string ExtractFileExtension(const string &path) {
 	return path.substr(dot_pos);
 }
 
-// Apply an explicit repo_path named parameter to a git:// URI (issue #17).
-//
-// - Relative URI (e.g. "git://src/auth.py@HEAD"): splice repo_path in so the file
-//   resolves against the specified repository instead of the process cwd. A relative
-//   URI that already includes repo_path as a prefix (e.g. "git://my-repo/src/auth.py")
-//   is spliced the same way — the caller is responsible for not double-supplying the
-//   prefix.
-// - Absolute URI (e.g. "git:///abs/repo/src/auth.py@HEAD"): combining with an explicit
-//   repo_path is always ambiguous, so raise an InvalidInputException.
-// - Empty repo_path or non-git:// URIs: returned unchanged.
-static string ApplyExplicitRepoPath(const string &uri, const string &repo_path) {
-	if (repo_path.empty() || !StringUtil::StartsWith(uri, "git://")) {
-		return uri;
-	}
-	const size_t prefix_len = 6; // strlen("git://")
-
-	// Normalize repo_path: strip trailing slashes so joining is consistent.
-	string repo = repo_path;
-	while (!repo.empty() && repo.back() == '/') {
-		repo.pop_back();
-	}
-	if (repo.empty()) {
-		return uri;
-	}
-
-	string rest = uri.substr(prefix_len);
-
-	// Absolute URI path (leading '/' after "git://" — i.e. three slashes in the source
-	// form) cannot be combined with an explicit repo_path: the two are independent
-	// specifications of the repository and silently preferring one would hide bugs.
-	if (!rest.empty() && rest[0] == '/') {
-		throw InvalidInputException(
-		    "git_read: conflicting repository paths: absolute URI '%s' cannot be combined with repo_path '%s'", uri,
-		    repo_path);
-	}
-
-	// Relative URI (or bare "git://@REF"): splice repo_path into the URI.
-	if (rest.empty() || rest[0] == '@') {
-		return "git://" + repo + rest;
-	}
-	return "git://" + repo + "/" + rest;
-}
-
 //===--------------------------------------------------------------------===//
 // Git Read Functions (both static and LATERAL support for reading blob content)
 //===--------------------------------------------------------------------===//
@@ -597,7 +554,7 @@ static unique_ptr<FunctionData> GitReadBind(ClientContext &context, TableFunctio
 	// resolves against the named repository; for absolute URIs that conflict with
 	// repo_path it raises an error. (Issue #17.)
 	if (!explicit_repo_path.empty()) {
-		uri = ApplyExplicitRepoPath(uri, explicit_repo_path);
+		uri = ApplyExplicitRepoPath(uri, explicit_repo_path, "git_read");
 		string normalized = explicit_repo_path;
 		while (!normalized.empty() && normalized.back() == '/') {
 			normalized.pop_back();

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -13,6 +13,45 @@
 
 namespace duckdb {
 
+string ApplyExplicitRepoPath(const string &uri, const string &repo_path, const string &function_name) {
+	if (repo_path.empty() || !StringUtil::StartsWith(uri, "git://")) {
+		return uri;
+	}
+	const size_t prefix_len = 6; // strlen("git://")
+
+	// Normalize repo_path: strip trailing slashes so joining is consistent.
+	string repo = repo_path;
+	while (!repo.empty() && repo.back() == '/') {
+		repo.pop_back();
+	}
+	if (repo.empty()) {
+		return uri;
+	}
+
+	string rest = uri.substr(prefix_len);
+
+	// Absolute URI path (leading '/' after "git://" -- i.e. three slashes in the source
+	// form) cannot be combined with an explicit repo_path: the two are independent
+	// specifications of the repository and silently preferring one would hide bugs.
+	if (!rest.empty() && rest[0] == '/') {
+		string prefix = function_name.empty() ? "" : function_name + ": ";
+		throw InvalidInputException("%sconflicting repository paths: absolute URI '%s' cannot be combined with "
+		                            "repo_path '%s'",
+		                            prefix, uri, repo_path);
+	}
+
+	// Relative URI (or bare "git://@REF"): splice repo_path into the URI.
+	if (rest.empty() || rest[0] == '@') {
+		return "git://" + repo + rest;
+	}
+	return "git://" + repo + "/" + rest;
+}
+
+// "", "." and "./" all mean the repository root rather than a path inside it.
+static bool IsRepoRootSpelling(const string &path) {
+	return path.empty() || path == "." || path == "./";
+}
+
 // Parse parameters using new unified signature: func(repo_path_or_uri, [optional_ref], [other_params...])
 UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_param_index) {
 	UnifiedGitParams params;
@@ -22,6 +61,34 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 		auto &first_arg = input.inputs[0];
 		if (first_arg.type().id() == LogicalTypeId::VARCHAR) {
 			params.repo_path_or_uri = first_arg.GetValue<string>();
+		}
+	}
+
+	// The repository can also arrive as the repo_path named parameter. Every function
+	// that registers it used to accept it and then never read it, so
+	// git_log(repo_path := 'x') answered from whatever repository the working directory
+	// sat in -- a well-formed commit list from the wrong repository, with nothing to
+	// show the parameter had been dropped (#36). git_read and git_blame already honoured
+	// it; these surfaces now agree with them, including how they read a positional
+	// argument alongside it: as a path INSIDE the named repository.
+	string explicit_repo_path;
+	for (const auto &kv : input.named_parameters) {
+		if (kv.first == "repo_path" && !kv.second.IsNull()) {
+			explicit_repo_path = kv.second.GetValue<string>();
+		}
+	}
+	while (!explicit_repo_path.empty() && explicit_repo_path.back() == '/') {
+		explicit_repo_path.pop_back();
+	}
+	if (!explicit_repo_path.empty()) {
+		if (IsRepoRootSpelling(params.repo_path_or_uri)) {
+			// Nothing but the repository was named: resolve it directly, which also
+			// keeps the repo_path output column reading as the caller wrote it.
+			params.repo_path_or_uri = explicit_repo_path;
+		} else {
+			string uri = StringUtil::StartsWith(params.repo_path_or_uri, "git://") ? params.repo_path_or_uri
+			                                                                       : "git://" + params.repo_path_or_uri;
+			params.repo_path_or_uri = ApplyExplicitRepoPath(uri, explicit_repo_path);
 		}
 	}
 

--- a/src/include/git_utils.hpp
+++ b/src/include/git_utils.hpp
@@ -27,6 +27,16 @@ struct UnifiedGitParams {
 	}
 };
 
+// Splice an explicit repo_path into a git:// URI.
+// - Relative URI (or a bare "git://@REF"): the repository is spliced in, so
+//   "git://src/x.py@HEAD" + repo "r" becomes "git://r/src/x.py@HEAD".
+// - Absolute URI ("git:///abs/repo/..."): the URI already names a repository, so
+//   combining it with repo_path is ambiguous and raises InvalidInputException
+//   rather than silently preferring one of them.
+// - Empty repo_path or a non-git:// string: returned unchanged.
+// function_name, when given, prefixes the error message.
+string ApplyExplicitRepoPath(const string &uri, const string &repo_path, const string &function_name = "");
+
 // Parse parameters using new unified signature: func(repo_path_or_uri, [optional_ref], [other_params...])
 UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_param_index = 1);
 

--- a/test/sql/git_branches_each_comprehensive.test
+++ b/test/sql/git_branches_each_comprehensive.test
@@ -80,11 +80,13 @@ SELECT COUNT(*) > 0 FROM test_repos t, LATERAL git_branches_each(t.repo_path) b
 ----
 true
 
-# Test git_branches with named parameters
-query T
-SELECT COUNT(*) > 0 as has_branches FROM git_branches(repo_path := 'test/tmp/main-repo')
+# Test git_branches with named parameters.
+# Asserted as an exact count on purpose: repo_path used to be dropped (#36), and
+# the enclosing repository answered instead -- which a "> 0" assertion accepts.
+query I
+SELECT COUNT(*) FROM git_branches(repo_path := 'test/tmp/main-repo')
 ----
-true
+3
 
 # Test git_branches count consistency
 query I

--- a/test/sql/git_repo_path_param.test
+++ b/test/sql/git_repo_path_param.test
@@ -1,0 +1,143 @@
+# name: test/sql/git_repo_path_param.test
+# description: the repo_path named parameter must select the repository (issue #36)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# These functions accept repo_path as a named parameter but resolved the
+# repository from the positional argument alone, so repo_path was bound and
+# then discarded and the query answered from whatever repository the working
+# directory sits in -- here, duck_tails itself. The fixtures are much smaller
+# than the enclosing repository, and the assertions name specific rows, so a
+# result taken from the wrong repository cannot satisfy them.
+#
+#   test/tmp/main-repo        3 commits (HEAD is a merge), 3 branches, 3 tags
+#   test/tmp/slash-refs-repo  1 commit on main, 2 on feature/foo
+
+# ==============================================================
+# git_log
+# ==============================================================
+
+query I
+SELECT COUNT(*) FROM git_log(repo_path := 'test/tmp/main-repo');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_log(repo_path := 'test/tmp/main-repo') WHERE message LIKE 'Merge develop%';
+----
+1
+
+# A second fixture of a different size, so the numbers cannot both be luck
+query I
+SELECT COUNT(*) FROM git_log(repo_path := 'test/tmp/slash-refs-repo');
+----
+1
+
+query I
+SELECT trim(message, chr(10)) FROM git_log(repo_path := 'test/tmp/slash-refs-repo');
+----
+main: initial commit
+
+# The named parameter and the positional path must name the same repository
+query I
+SELECT (SELECT COUNT(*) FROM git_log(repo_path := 'test/tmp/main-repo'))
+     = (SELECT COUNT(*) FROM git_log('test/tmp/main-repo'));
+----
+true
+
+# ...and neither of them is the enclosing repository, which is much bigger
+query I
+SELECT (SELECT COUNT(*) FROM git_log('.')) > (SELECT COUNT(*) FROM git_log(repo_path := 'test/tmp/main-repo'));
+----
+true
+
+# ==============================================================
+# git_branches, git_tags, git_parents (same helper, same defect)
+# ==============================================================
+
+query I
+SELECT COUNT(*) FROM git_branches(repo_path := 'test/tmp/main-repo');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_branches(repo_path := 'test/tmp/main-repo') WHERE branch_name = 'feature/test';
+----
+1
+
+query I
+SELECT COUNT(*) FROM git_tags(repo_path := 'test/tmp/main-repo');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_tags(repo_path := 'test/tmp/main-repo') WHERE tag_name = 'v1.0.0';
+----
+1
+
+# main-repo has 3 commits with 3 parent edges in total (HEAD is a merge)
+query I
+SELECT COUNT(*) FROM git_parents(repo_path := 'test/tmp/main-repo');
+----
+3
+
+query I
+SELECT (SELECT COUNT(*) FROM git_tags(repo_path := 'test/tmp/main-repo'))
+     = (SELECT COUNT(*) FROM git_tags('test/tmp/main-repo'));
+----
+true
+
+# ==============================================================
+# A positional argument alongside repo_path names a path INSIDE that
+# repository, which is how git_read and git_blame already read it
+# ==============================================================
+
+# src/main.py exists only in main-repo, and one commit there touches it
+query I
+SELECT COUNT(*) FROM git_log('src/main.py', repo_path := 'test/tmp/main-repo');
+----
+1
+
+# '.' means the repository root, not a path filter that matches nothing
+query I
+SELECT COUNT(*) FROM git_log('.', repo_path := 'test/tmp/main-repo');
+----
+3
+
+# A relative git:// URI is spliced onto the named repository, ref and all
+query I
+SELECT COUNT(*) FROM git_log('git://data/rows.csv@feature/foo', repo_path := 'test/tmp/slash-refs-repo');
+----
+2
+
+# An absolute URI names the repository itself, so combining the two is refused
+# rather than silently preferring one (same rule git_read applies)
+statement error
+SELECT * FROM git_log('git:///absolute/path/repo/file.txt@HEAD', repo_path := '/other/repo');
+----
+conflicting repository paths
+
+# ==============================================================
+# Regression: without repo_path nothing changes
+# ==============================================================
+
+query I
+SELECT COUNT(*) FROM git_log('test/tmp/main-repo');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_tags('test/tmp/main-repo');
+----
+3
+
+query I
+SELECT COUNT(*) > 0 FROM git_log('.');
+----
+true


### PR DESCRIPTION
Fixes #36.

## The defect

`ParseUnifiedGitParams` read only `input.inputs[0]`, so every function registering `repo_path` as a named parameter accepted it, bound it, and discarded it — answering from whatever repository the working directory sat in. Confirmed before the fix, from the duck_tails checkout:

| call | returned | correct |
|---|---|---|
| `git_log(repo_path := 'test/tmp/main-repo')` | 148 (duck_tails' own commits) | 3 |
| `git_tags(repo_path := 'test/tmp/main-repo')` | 11 | 3 |
| `git_branches(repo_path := 'test/tmp/main-repo')` | 19 | 3 |
| `git_parents(repo_path := 'test/tmp/main-repo')` | 168 | 3 |

The issue named `git_log`; it was four functions, all through the one shared helper. `git_read` and `git_blame` were unaffected because each already handled `repo_path` itself — which is what made the surfaces disagree.

## The fix

`ParseUnifiedGitParams` now consults `input.named_parameters`, and reads a positional argument alongside `repo_path` the way `git_read` and `git_blame` already do: **as a path inside the named repository**. `""`, `"."` and `"./"` mean the repository root.

`git_read`'s private `ApplyExplicitRepoPath` moves into `git_utils` so the composition — including its refusal to combine an absolute `git://` URI with `repo_path` — is one implementation shared by every surface instead of two that can drift apart. `git_read` keeps its exact behaviour, error message included.

## Tests

`test/sql/git_repo_path_param.test` (20 assertions), written first and watched fail on its first assertion (148 where 3 was expected).

The fixtures are far smaller than the enclosing repository, and the assertions name specific rows — the merge commit, `feature/test`, `v1.0.0`, the sole commit of `slash-refs-repo` — so a result taken from the wrong repository cannot satisfy them. It also covers a positional path inside the named repo, `'.'` as the repo root, a relative `git://` URI spliced onto the named repo (ref and all), and the absolute-URI conflict error.

**One pre-existing test passed against this bug** and is corrected here: `git_branches_each_comprehensive.test` asserted `COUNT(*) > 0` for `git_branches(repo_path := 'test/tmp/main-repo')`, which the enclosing repository's 19 branches satisfied just as well as the fixture's 3. It now asserts the exact count.

Suite: `All tests passed (995 assertions in 59 test cases)`; `make format-check` passes.

## Not in this PR — a defect found while assessing #28

`git_log`, `git_tree` and `read_text` return **silently empty** when the path they are given differs textually from the path libgit2 resolves for the same repository. Reproduced on Linux through a symlink:

```
git_log('/…/scratchpad/link-repo')                    -> 0 rows   (symlink to main-repo)
git_log('/…/duck_tails/test/tmp/main-repo')           -> 3 rows   (same repo, real path)
git_tree('/…/scratchpad/link-repo')                   -> 0 rows
read_text('git:///…/scratchpad/link-repo/README.md@HEAD') -> 0 rows, no error
git_branches('/…/scratchpad/link-repo')               -> 3 rows   (does not use file_path, so unaffected)
```

`GitPath::Parse` compares the *lexically* normalized input against the repository path libgit2 discovered (fully resolved). When they do not share a prefix it falls back to `result.file_path = url + path_suffix` — the entire path becomes a path filter inside the repo, matches nothing, and the query returns an empty result with no error.

Unchanged by #33 and by this PR (verified against a build of `0ab6743`, pre-#33: same 0 rows). Worth its own issue — details in my report and in the comment on #28.
