### PR TITLE
fix: implement the positional Read on GitFileSystem (v2.0 canary)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -32,21 +32,13 @@ jobs:
       # transport this extension is built around is unsupported on Windows, so
       # Windows builds/tests are not maintained here.
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
-      # TEMPORARY DIAGNOSTIC -- REVERT BEFORE MERGE.
-      # The v2.0 build is green; 6 tests fail at RUNTIME. This runner's harness
-      # prints the failing query and "FAILED" but NOT the actual-vs-expected diff
-      # or any exception text, so the log says nothing about WHY. Re-running the
-      # same files serially through the raw unittest binary does print it.
-      # post_build_command runs after `make release`, before the test phase;
-      # `|| true` keeps the step green so the log survives either way.
-      post_build_command: >-
-        bash test/fixtures/setup_fixtures.sh setup || true ;
-        for t in git_log_path_filter debug_complex_lateral_no_verification
-        duck_tails_comprehensive git_read_each_comprehensive
-        git_tags_each_comprehensive git_tags_comprehensive ; do
-        echo "===== DIAG $t =====" ;
-        ./build/release/test/unittest "test/sql/$t.test" || true ;
-        done
+      # Fixtures: test/Makefile.inc hooks `test_setup` onto both the
+      # test_<type> targets this runner uses and the test_<type>_internal ones
+      # the stable runner uses, so each path sets its own fixtures up inside the
+      # environment that runs the tests. This job used to carry a
+      # post_build_command doing that on the host instead -- a step introduced as
+      # temporary in #32 and never reverted, which had become the canary's only
+      # source of fixtures.
 
   duckdb-stable-build:
     name: Build extension binaries

--- a/src/git_filesystem.cpp
+++ b/src/git_filesystem.cpp
@@ -604,6 +604,20 @@ int64_t GitFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes) 
 	}
 }
 
+// Positional read. Blob content is already fully in memory (and the LFS handle
+// delegates to a seekable handle), so this is a seek followed by the sequential
+// read. DuckDB requires the positional form to deliver every requested byte or
+// throw -- a short read here would look like a truncated file to the caller.
+void GitFileSystem::Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) {
+	Seek(handle, location);
+	int64_t bytes_read = Read(handle, buffer, nr_bytes);
+	if (bytes_read != nr_bytes) {
+		throw IOException("Could not read all bytes from git file '%s': requested %s bytes at offset %s, got %s",
+		                  handle.GetPath(), std::to_string(nr_bytes), std::to_string(location),
+		                  std::to_string(bytes_read));
+	}
+}
+
 void GitFileSystem::Seek(FileHandle &handle, idx_t location) {
 	if (auto *lfs_handle = dynamic_cast<GitLFSFileHandle *>(&handle)) {
 		lfs_handle->Seek(location);

--- a/src/include/git_filesystem.hpp
+++ b/src/include/git_filesystem.hpp
@@ -183,6 +183,11 @@ public:
 
 	// File operations delegation to GitFileHandle
 	int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override;
+	// Positional read. DuckDB v1.5's readers only ever used the sequential form
+	// above, so this was left to the base class -- which throws. v2.0's readers
+	// call this one, which turned every read through git:// into
+	// "GitFileSystem: Read (with location) is not implemented!".
+	void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override;
 	void Seek(FileHandle &handle, idx_t location) override;
 	idx_t SeekPosition(FileHandle &handle) override;
 	void Reset(FileHandle &handle) override;

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -6,7 +6,21 @@
 test_setup:
 	@bash test/fixtures/setup_fixtures.sh setup
 
-# Add fixture setup as dependency to test targets (defined in duckdb_extension.Makefile)
+# Fixture setup has to run wherever the tests run, and extension-ci-tools has
+# used two different target names for that:
+#
+#   v1.5-variegata (the stable job): test_<type> wraps test_<type>_internal
+#   main (the duckdb-main canary):   test_<type> runs the tests itself; the
+#                                    _internal targets no longer exist
+#
+# Hooking only the _internal names meant the canary never ran this, which is why
+# its fixture setup had to be carried by a post_build_command in the workflow --
+# a step marked "revert before merge" in #32 that had quietly become
+# load-bearing. Hook both names so each path sets its own fixtures up, and the
+# workflow needs no test-specific scaffolding.
 test_release_internal: test_setup
 test_debug_internal: test_setup
 test_reldebug_internal: test_setup
+test_release: test_setup
+test_debug: test_setup
+test_reldebug: test_setup

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -3,8 +3,18 @@
 
 .PHONY: test_setup
 
+# SKIP_TESTS is set by extension-ci-tools for the pass that does not run the
+# tests. On linux the test phase invokes `make test_<type>` TWICE -- once inside
+# the container, then again on the host with LINUX_CI_IN_DOCKER=0, where the
+# Makefile sets SKIP_TESTS=1 and runs nothing. Fixture setup must follow the
+# tests: the container pass creates test/tmp as root, and a second setup from the
+# host (uid 1001) cannot write into it and fails the job.
 test_setup:
-	@bash test/fixtures/setup_fixtures.sh setup
+	@if [ "$(SKIP_TESTS)" = "1" ]; then \
+		echo "Fixture setup skipped: tests are skipped in this run."; \
+	else \
+		bash test/fixtures/setup_fixtures.sh setup; \
+	fi
 
 # Fixture setup has to run wherever the tests run, and extension-ci-tools has
 # used two different target names for that:


### PR DESCRIPTION
Root-causes and fixes the v2.0 canary failures, and retires the temp workflow step that had become load-bearing.

## 1. Product defect: the positional `Read` was never implemented

`GitFileSystem` overrode only the sequential `Read(handle, buffer, nr_bytes)`. The positional `Read(handle, buffer, nr_bytes, location)` was left to the base class, which throws. v1.5's readers only ever call the sequential form; **v2.0's readers call the positional one**, so every read through `git://` died with:

```
Not implemented Error: GitFileSystem: Read (with location) is not implemented!
```

**Evidence — reproduced locally, not inferred.** I built duck_tails `a42cef4` against duckdb main (`154c2c8d5f`, v2.1.0-dev) in a worktree; the canary log confirms it builds that same duckdb commit.

| build | before | after |
|---|---|---|
| duckdb main | **13 of 59 test files failed** | **995 assertions in 59 test cases, all passing** |
| duckdb v1.5.4 | 995 assertions, green | 995 assertions, green |

All 13 carried one message — one defect, not thirteen:

```
$ grep -A3 '^Actual result:' v2_suite.log | sort | uniq -c
     13 Not implemented Error: GitFileSystem: Read (with location) is not implemented!
```

The overload exists in both versions (`file_system.hpp:156` on v1.5, `:213` on main), so `override` compiles against both and v1.5 behaviour is unchanged. Blob content is already in memory and the LFS handle delegates to a seekable handle, so the positional read is a seek plus the sequential read; it raises if it cannot deliver every byte, rather than silently looking like a truncated file.

## 2. Harness defect: fixtures were never set up on the canary path

extension-ci-tools uses two target names: v1.5-variegata's `test_<type>` wraps `test_<type>_internal`; main's `test_<type>` runs the tests itself and has **no** `_internal` target. `test/Makefile.inc` hooked only the `_internal` names, so the canary never ran fixture setup.

That gap was covered by a `post_build_command` in the workflow, added as *"TEMP … revert before merge"* in #32 and never reverted — so it had become the canary's only source of fixtures, and a naive revert would have removed fixture setup from that job entirely. It also ran on the host rather than in the container that runs the tests, and its diagnostic half printed nothing but `libduckdb.so: cannot open shared object file` (that library lives in `build/release/src`), so it never produced the diagnostics it was added for.

Hooking both target names lets each runner set its own fixtures up inside the environment that runs its tests. **Verified in the canary container:** the hook fires and fixtures are extracted to `/duckdb_build_dir/test/tmp` before the test phase. The temp step is gone.

## 3. What is NOT fixed here, and why I am not claiming it is

The canary reports six failing tests. **They are not the defect above, and they are not a v2.0 product break.** Evidence gathered by running diagnostics inside the canary container:

* The same query that fails inside a test **succeeds from the duckdb CLI in that same container**: `git_branches('test/tmp/main-repo')` returns 3, relative and absolute paths alike, first call and repeated.
* Fixtures are present and correct in the container (`ls` and `git -C test/tmp/main-repo branch` both verified there), and are now created there rather than on the host.
* The working directory the test framework gives a test is the repository root (probed by asserting a wrong value so the diff printed the real `glob('*')`).
* Not ownership: git reports `safe.directory=*` and reads the fixtures fine as root.
* Not file descriptors: the container's limit is 65536, and the suite passes locally at a limit of 1024.
* Not the parallel runner: duckdb main's `run_tests.py` with the canary's exact parameters (`--workers 3 --batch-size 10 --retry 2`) passes 59/59 locally.
* Not test ordering: the six pass locally in one process together, individually, and in a full sequential run.

The failures appear only under the sqllogictest runner inside that container, with the same binary, the same duckdb commit and the same fixtures that work from the CLI a second earlier. That is an environment interaction in the canary job, and it should be chased as one rather than patched as a product bug — the shape of it is exactly the trap that cost a sibling repo hours (an ABI mismatch wearing the costume of wrong output).
