### PR TITLE
ci: declare git safe.directory at system level so the canary is a real signal

### DIFF
--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -3,6 +3,24 @@
 
 .PHONY: test_setup
 
+# libgit2 ownership vs. the unittest binary's HOME sandbox.
+#
+# The CI image declares `git config --global --add safe.directory "*"` -- i.e.
+# in /root/.gitconfig, under $HOME. duckdb main's unittest binary (test/unittest.cpp)
+# setenv()s HOME to a fresh, empty per-run sandbox unless --keep-home is passed, so
+# libgit2 stops finding that declaration. It then falls back to its ownership check
+# for every repository the extension opens, and nothing we open is owned by root:
+# the workspace is a bind mount owned by the host runner (uid 1001) and `tar -x` run
+# as root restores the uid recorded in the fixture tarballs (uid 501). Every
+# git_repository_open returns GIT_EOWNER, so every git:// path fails discovery and
+# essentially the whole suite fails -- reported as only "6 failed" because
+# run_tests.py counts failed BATCHES, not failed tests.
+#
+# duckdb v1.5.4's unittest never touches HOME, which is why the stable pipeline is
+# unaffected. libgit2 resolves the SYSTEM config (/etc/gitconfig) without consulting
+# $HOME, so re-declaring safe.directory there survives the sandbox. Root-only: a
+# no-op outside the CI container, where the files are already owned by the caller.
+#
 # SKIP_TESTS is set by extension-ci-tools for the pass that does not run the
 # tests. On linux the test phase invokes `make test_<type>` TWICE -- once inside
 # the container, then again on the host with LINUX_CI_IN_DOCKER=0, where the
@@ -14,6 +32,11 @@ test_setup:
 		echo "Fixture setup skipped: tests are skipped in this run."; \
 	else \
 		bash test/fixtures/setup_fixtures.sh setup; \
+		if [ "$$(id -u 2>/dev/null || echo 1)" = "0" ]; then \
+			git config --file /etc/gitconfig --replace-all safe.directory '*' 2>/dev/null \
+				&& echo "safe.directory='*' declared in /etc/gitconfig (survives the unittest HOME sandbox)" \
+				|| echo "warning: could not declare safe.directory in /etc/gitconfig"; \
+		fi; \
 	fi
 
 # Fixture setup has to run wherever the tests run, and extension-ci-tools has


### PR DESCRIPTION
Makes the duckdb-main canary a real signal. `test/Makefile.inc` only; `src/` untouched.

## Cause

duckdb **main**'s unittest binary sandboxes `$HOME` (`test/unittest.cpp:178-190`: `setenv("HOME", <run-root>-home, 1)` into a fresh empty dir unless `--keep-home`). duckdb **v1.5.4**'s `unittest.cpp` never touches HOME — that is the entire stable/canary difference.

extension-ci-tools' Dockerfile sets `git config --global --add safe.directory "*"`, which lands in `/root/.gitconfig` — under `$HOME`. libgit2 resolves global config via `$HOME`, so the sandbox hides it. `validate_ownership()` then rejects every repo whose uid != euid with `GIT_EOWNER`.

Nothing we open is root-owned: `owner(.git)=1001` (bind-mounted workspace), `owner(test/tmp/main-repo/.git)=501` (root's `tar -x` restores the uid in the fixture tarballs). That is why host-side and container-side setup failed identically.

## Fix

Declare `safe.directory` in `/etc/gitconfig`, which libgit2 hardcodes as its system dir (`sysdir.c:282`) and resolves without `$HOME`. Root-only, no-op elsewhere.

## Evidence

One run, same container, same binary, same second:

```
--- unittest, default:      Binder Error: ... No git repository found ...
--- unittest, --keep-home:  All tests passed (29 assertions in 1 test case)
```

`--keep-home` was the only variable. After the fix: `ran tests: 59 passed, 0 skipped in 13s`.

## The "6 failures" was never 6 failures

`duckdb/scripts/ci/run_tests.py` counts failed *batches*, not failed tests — `record_failure()` fires once per batch, and `passed = total - failed - skipped` is derived by subtraction. 59 tests / batch-size 10 = 6 batches, so "53 passed / 6 failed" meant **all six batches failed**. The single name printed per batch is `preferred_assertion`, picked by `max((score, idx))`, i.e. the *last* failing test in the batch — which is why failures appeared to cluster at positions 8-9. 58 of 59 test files touch git; essentially the whole suite was down.

## Note

`src/git_filesystem.cpp:197` rewrites *any* discovery failure as "Searched up directory tree ... but found no .git directory", which sent this investigation toward CWD for hours. Worth surfacing the underlying libgit2 error. Not changed here.

## Upstream

- **extension-ci-tools**: all four Dockerfiles use `git config --global`; `--system` would be HOME-independent. Affects any extension using libgit2 under duckdb main.
- **duckdb main `run_tests.py`**: reports batch failures as test failures, making a ~95%-broken suite read as "6 failed".
