### PR TITLE
ci: add github.event_name to the concurrency key

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -8,7 +8,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' && github.sha || '' }}
+  # github.event_name is part of the key on purpose. Without it a push to a
+  # branch and a workflow_dispatch on that same branch collide: same ref, same
+  # sha, both with empty head_ref/base_ref. cancel-in-progress then kills the
+  # push run every time the canary is dispatched by hand, and a cancelled run
+  # reads as a failed one on the checks dashboard.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adds `github.event_name` to the concurrency key. Same fix already applied across the rest of the fleet; duck_tails was the one repo still missing it.

## Why

Without `event_name`, a **push** to a branch and a **workflow_dispatch** on that same branch produce an identical key — same `github.ref`, same `github.sha`, both with empty `head_ref` and `base_ref`. `cancel-in-progress: true` then kills one of them.

Because duck_tails' canary is `workflow_dispatch`-only, dispatching it by hand is a routine operation — and every hand-dispatch cancels the push run for the same ref. **A cancelled run renders as a failed one on the checks dashboard**, which is a standing source of phantom red.

This is observable on PR #40 right now: six of its checks are `CANCELLED`.

## Secondary effect

The key also carries `github.sha` for non-main refs, so on a branch two pushes never share a key and `cancel-in-progress` can never supersede an older run. That is left as-is here — it is a separate trade-off (wasted runner time vs. keeping every push's result) and not what causes the phantom failures.

## Scope

One file, `.github/workflows/MainDistributionPipeline.yml`. No job logic, no build change, no `src/` change. YAML re-parses; all three jobs (`duckdb-next-build`, `duckdb-stable-build`, `code-quality-check`) intact.

Independent of #40, which fixes the canary's git `safe.directory` problem. Both are needed for duck_tails to be green and trustworthy: #40 makes the canary *work*, this makes its results *stop cancelling other runs*.
