### PR TITLE
Report the real libgit2 error instead of rewriting every failure as "no .git directory"

### DIFF
--- a/src/git_filesystem.cpp
+++ b/src/git_filesystem.cpp
@@ -16,13 +16,12 @@ namespace duckdb {
 // Forward declarations for repository discovery functions
 //===--------------------------------------------------------------------===//
 
-static string FindGitRepository(const string &path);
+static string FindGitRepository(const string &path, const string &display_path);
 static bool IsGitRepository(const string &path);
 static bool PathExists(const string &path);
 static string GetDirectoryFromPath(const string &path);
 static string GetParentDirectory(const string &path);
 static string NormalizePath(const string &path);
-
 //===--------------------------------------------------------------------===//
 // Revision / path-suffix splitting
 //===--------------------------------------------------------------------===//
@@ -150,8 +149,12 @@ GitPath GitPath::Parse(const string &git_url) {
 		result.file_path = path_suffix.empty() ? "" : path_suffix.substr(1); // Remove leading /
 	} else {
 		// Use repository discovery for ALL paths (simple and complex)
-		try {
-			result.repository_path = FindGitRepository(url);
+		{
+			// FindGitRepository reports its own failures, naming the URI as the
+			// caller wrote it. It used to be wrapped in a catch that replaced every
+			// one of them with "found no .git directory" -- true only for
+			// GIT_ENOTFOUND, and actively misleading for the rest (#42).
+			result.repository_path = FindGitRepository(url, git_url);
 
 			// Ask the repository where the ref ends and the path begins.
 			SplitRevisionFromPath(result.repository_path, result.revision, path_suffix);
@@ -195,15 +198,6 @@ GitPath GitPath::Parse(const string &git_url) {
 					}
 				}
 			}
-		} catch (const IOException &e) {
-			// No fallback - fail fast with clear error message
-			string search_path = url;
-			if (url.find('/') != string::npos) {
-				search_path = GetDirectoryFromPath(url);
-			}
-			throw IOException("No git repository found for path '%s'. "
-			                  "Searched up directory tree from '%s' but found no .git directory.",
-			                  git_url.c_str(), search_path.c_str());
 		}
 	}
 
@@ -1095,9 +1089,68 @@ static string GetParentDirectory(const string &path) {
 	return clean_path.substr(0, last_slash);
 }
 
+// Names the libgit2 error codes worth naming, so a report carries the symbol a
+// reader can search for rather than a bare integer.
+static const char *GitErrorCodeName(int code) {
+	switch (code) {
+	case GIT_ERROR:
+		return "GIT_ERROR";
+	case GIT_ENOTFOUND:
+		return "GIT_ENOTFOUND";
+	case GIT_EEXISTS:
+		return "GIT_EEXISTS";
+	case GIT_EAMBIGUOUS:
+		return "GIT_EAMBIGUOUS";
+	case GIT_EBUFS:
+		return "GIT_EBUFS";
+	case GIT_EINVALIDSPEC:
+		return "GIT_EINVALIDSPEC";
+	case GIT_ECONFLICT:
+		return "GIT_ECONFLICT";
+	case GIT_ELOCKED:
+		return "GIT_ELOCKED";
+	case GIT_EAUTH:
+		return "GIT_EAUTH";
+	case GIT_ECERTIFICATE:
+		return "GIT_ECERTIFICATE";
+	case GIT_EDIRECTORY:
+		return "GIT_EDIRECTORY";
+	case GIT_EOWNER:
+		return "GIT_EOWNER";
+	default:
+		return nullptr;
+	}
+}
+
+// Renders whatever libgit2 last recorded, plus the symbolic code, for a call the
+// caller has already seen fail.
+static string DescribeGitError(int code) {
+	const git_error *e = git_error_last();
+	string detail = (e && e->message) ? string(e->message) : string("no further detail from libgit2");
+	const char *name = GitErrorCodeName(code);
+	if (name) {
+		detail += StringUtil::Format(" (%s)", name);
+	} else {
+		detail += StringUtil::Format(" (libgit2 error %d)", code);
+	}
+	return detail;
+}
+
 // Finds the git repository root directory by walking up the directory tree from the given path
 // Uses libgit2's git_repository_discover for cross-platform path handling
-static string FindGitRepository(const string &path) {
+//
+// `display_path` is the spelling to name in an error -- the URI the caller
+// actually wrote, which `path` no longer is by the time it reaches here.
+//
+// Every failure used to leave here, and then leave GitPath::Parse, as "Searched
+// up directory tree ... but found no .git directory" regardless of what libgit2
+// had said. That message names a cause instead of reporting one: it is accurate
+// only for GIT_ENOTFOUND, and for anything else -- GIT_EOWNER above all, where
+// the repository is sitting right there and only ownership validation refused
+// it -- it sends the reader looking for a directory that is not missing. Two
+// separate investigations lost hours to it (#42), with the real error one
+// git_error_last() call away the whole time.
+static string FindGitRepository(const string &path, const string &display_path) {
 	// First, try to find an existing starting point for discovery
 	string start_path = path;
 
@@ -1129,38 +1182,59 @@ static string FindGitRepository(const string &path) {
 	if (error == 0) {
 		// Open the repository to get the proper workdir (handles submodules correctly)
 		git_repository *repo = nullptr;
+		string git_dir = discovered_path.ptr ? string(discovered_path.ptr) : string();
 		error = git_repository_open(&repo, discovered_path.ptr);
 		git_buf_dispose(&discovered_path);
 
-		if (error == 0) {
-			string result;
-
-			// For worktrees and submodules, get the workdir path
-			// For bare repos, use the repo path
-			const char *workdir = git_repository_workdir(repo);
-			if (workdir) {
-				result = workdir;
-			} else {
-				// Bare repository - use the repository path itself
-				result = git_repository_path(repo);
-			}
-
-			git_repository_free(repo);
-
-			// Remove trailing slashes
-			while (!result.empty() && (result.back() == '/' || result.back() == '\\')) {
-				result.pop_back();
-			}
-
-			return result.empty() ? "." : result;
+		if (error != 0) {
+			// Discovery succeeded, so the .git directory is there and was found.
+			// Whatever went wrong happened on the way in, and saying "no .git
+			// directory" here would be flatly false.
+			throw IOException("Found a git directory at '%s' for path '%s' but could not open it: %s", git_dir,
+			                  display_path, DescribeGitError(error));
 		}
 
-		// Failed to open - fall through to error
-	} else {
-		git_buf_dispose(&discovered_path);
+		// For worktrees and submodules, get the workdir path
+		// For bare repos, use the repo path
+		string result;
+		const char *workdir = git_repository_workdir(repo);
+		if (workdir) {
+			result = workdir;
+		} else {
+			// Bare repository - use the repository path itself
+			result = git_repository_path(repo);
+		}
+
+		git_repository_free(repo);
+
+		// Remove trailing slashes
+		while (!result.empty() && (result.back() == '/' || result.back() == '\\')) {
+			result.pop_back();
+		}
+
+		return result.empty() ? "." : result;
 	}
 
-	throw IOException("No git repository found for path: %s", path);
+	git_buf_dispose(&discovered_path);
+
+	if (error == GIT_ENOTFOUND) {
+		// The one case where naming the cause is reporting it: libgit2 walked the
+		// tree and there was genuinely nothing there.
+		throw IOException("No git repository found for path '%s'. "
+		                  "Searched up directory tree from '%s' but found no .git directory.",
+		                  display_path, start_path);
+	}
+
+	string message = StringUtil::Format("Could not discover a git repository for path '%s' (searched from '%s'): %s",
+	                                    display_path, start_path, DescribeGitError(error));
+	if (error == GIT_EOWNER) {
+		// GIT_EOWNER is an environment problem with one well-known remedy, and
+		// the repository is present -- the reader needs to be told that, not sent
+		// looking for a .git directory that is right in front of them.
+		message += ". The repository exists but is owned by another user; add it to "
+		           "safe.directory (git config --global --add safe.directory <path>) to allow access";
+	}
+	throw IOException(message);
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/fixtures/setup_fixtures.sh
+++ b/test/fixtures/setup_fixtures.sh
@@ -81,6 +81,16 @@ setup_fixtures() {
     echo "Generating slash-bearing ref fixture..."
     bash "$FIXTURES_DIR/../scripts/setup_slash_refs_fixture.sh" "$TEMP_DIR"
 
+    # A directory whose .git is present but unreadable to libgit2 -- a `.git`
+    # file (the form submodules and worktrees use) with contents that are not
+    # "gitdir: <path>". Discovery fails with GIT_ERROR, not GIT_ENOTFOUND, and
+    # every such failure used to be rewritten as "Searched up directory tree ...
+    # but found no .git directory" -- flatly false here, and the reason a
+    # GIT_EOWNER failure cost two investigations several hours each (#42).
+    echo "Creating malformed-gitfile-repo (non-ENOTFOUND discovery failure)..."
+    mkdir -p "$TEMP_DIR/malformed-gitfile-repo"
+    echo "this is not a gitdir pointer" > "$TEMP_DIR/malformed-gitfile-repo/.git"
+
     echo "Fixtures extracted successfully to: $TEMP_DIR"
     echo "Run '$0 validate' to verify fixture integrity"
 }

--- a/test/sql/git_discovery_errors.test
+++ b/test/sql/git_discovery_errors.test
@@ -1,0 +1,68 @@
+# name: test/sql/git_discovery_errors.test
+# description: discovery failures must report their cause, not assert one (issue #42)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/repository';
+
+statement ok
+PRAGMA threads=1;
+
+# Every failure of git_repository_discover was caught and rewritten as
+# "Searched up directory tree ... but found no .git directory". That names a
+# cause instead of reporting one: it is accurate only for GIT_ENOTFOUND. The
+# canary failure behind #40 was libgit2 returning GIT_EOWNER -- the repository
+# was present and correct, and only ownership validation refused it -- and
+# because the catch-all rewrote the message, two separate investigations spent
+# hours on working-directory and fixture-path theories. The real error was one
+# git_error_last() call away the whole time.
+
+# test/tmp/malformed-gitfile-repo has a .git FILE whose contents are not a
+# "gitdir:" pointer. libgit2 returns GIT_ERROR, not GIT_ENOTFOUND, so the old
+# message claimed no .git directory was found for a repository marker sitting
+# right there.
+statement error
+SELECT * FROM git_log('test/tmp/malformed-gitfile-repo');
+----
+malformed
+
+# libgit2's symbolic error code travels with the message, so a reader has
+# something to search for.
+statement error
+SELECT * FROM git_log('test/tmp/malformed-gitfile-repo');
+----
+GIT_ERROR
+
+# And the message must NOT claim the tree was searched and nothing was found.
+statement error
+SELECT * FROM git_log('test/tmp/malformed-gitfile-repo');
+----
+<!REGEX>:(?s).*found no .git directory.*
+
+# The one case where naming the cause IS reporting it must keep its wording:
+# libgit2 really did walk the tree and find nothing.
+statement error
+SELECT * FROM git_log('/nonexistent-top-level-directory-for-duck-tails/repo');
+----
+Searched up directory tree
+
+statement error
+SELECT * FROM git_log('/nonexistent-top-level-directory-for-duck-tails/repo');
+----
+found no .git directory
+
+# The same path through the filesystem surface rather than a table function.
+statement error
+SELECT * FROM read_text('git://test/tmp/malformed-gitfile-repo/README.md@HEAD');
+----
+malformed
+
+# A working repository must still resolve, through both spellings.
+query I
+SELECT COUNT(*) > 0 FROM git_log('test/tmp/main-repo');
+----
+true


### PR DESCRIPTION
## Title

fix: report why repository discovery failed instead of asserting a cause (#42)

**Branch:** `fix/42-discovery-error-reporting` → `main`
**Head:** `0d6dc0dc0dd3f4f4291ae17180e0cffc66b07b83`
**Base:** `main`
**Closes:** #42
**Note:** `fix/38-path-spelling` is stacked on this branch and should be merged after it.

---

Every failure of `git_repository_discover` left `FindGitRepository` as `IOException("No git repository found for path: %s")`, and `GitPath::Parse` caught that and rewrote it as

> No git repository found for path '<uri>'. Searched up directory tree from '<dir>' but found no .git directory.

That message names a cause rather than reporting one. It is accurate for `GIT_ENOTFOUND` and for nothing else, and libgit2 has plenty of other reasons to refuse a repository that is sitting right there.

The canary failure fixed in #40 was `GIT_EOWNER` — ownership validation — with the repository present and correct the whole time. Because the catch-all rewrote it, two separate investigations spent hours on working-directory and fixture-path theories while the message pointed away from the cause. `git_error_last()` had the answer throughout.

## Demonstrated

A `.git` **file** (the form submodules and worktrees use) whose contents are not a `gitdir:` pointer. libgit2 returns `GIT_ERROR`, not `GIT_ENOTFOUND`:

```
before: No git repository found for path '...'. Searched up directory tree
        from '...' but found no .git directory.

after:  Could not discover a git repository for path '...' (searched from '...'):
        the `.git` file at '.../.git' is malformed (GIT_ERROR)
```

The `.git` marker is right there. The old message said it was not.

## What changed

`FindGitRepository` now takes the URI as the caller spelled it, so it can report its own failures, and distinguishes three cases:

- **`GIT_ENOTFOUND`** keeps the existing wording — libgit2 really did walk the tree and find nothing, so naming the cause *is* reporting it. Existing tests that match `No git repository found for path` are unaffected.
- **Any other discovery failure** surfaces `git_error_last()->message` plus the symbolic code (`GIT_EOWNER`, `GIT_ERROR`, `GIT_ELOCKED`, …), so the reader has a symbol to search for. `GIT_EOWNER` additionally gets the `safe.directory` remedy — it is an environment problem with one well-known fix, and the user is otherwise told to look for a `.git` directory they can see.
- **Discovery succeeding and the subsequent open failing** is reported as exactly that, instead of as a missing `.git` directory.

The catch in `GitPath::Parse` goes away with it; it existed only to perform the rewrite.

## Verification

- `make release && make test` on this branch: **1004 assertions in 60 test cases, all passed** (baseline `main`: 995 in 59).
- `make format-check`: passes.
- New `test/sql/git_discovery_errors.test` (9 assertions). It pins the new reporting, pins the `GIT_ENOTFOUND` wording so that case cannot drift, and uses `<!REGEX>` to assert the non-ENOTFOUND message does **not** claim the tree was searched and nothing found — the specific falsehood this fixes.
- `test/fixtures/setup_fixtures.sh` generates `test/tmp/malformed-gitfile-repo`.

`GIT_EOWNER` itself cannot be provoked in this environment without a second uid, so the non-ENOTFOUND branch is exercised through the malformed-gitfile case, which takes exactly the same code path.
