### PR TITLE
Locate the repo root in the caller's spelling; stop silently returning zero rows

### DIFF
--- a/src/git_filesystem.cpp
+++ b/src/git_filesystem.cpp
@@ -22,6 +22,120 @@ static bool PathExists(const string &path);
 static string GetDirectoryFromPath(const string &path);
 static string GetParentDirectory(const string &path);
 static string NormalizePath(const string &path);
+static bool IsDirectory(const string &path);
+
+//===--------------------------------------------------------------------===//
+// Locating an input inside its repository
+//===--------------------------------------------------------------------===//
+
+// git_repository_discover for `path`, returning the .git directory it found.
+// Used as an identity for "which repository is this directory in".
+//
+// Note: a failed call leaves libgit2's thread-local error slot set. Callers here
+// read that slot only straight after a call they saw fail, so a stale entry is
+// never reported.
+static bool DiscoverGitDir(const string &path, string &out_git_dir) {
+	git_buf buf = {0};
+	if (git_repository_discover(&buf, path.c_str(), 0, nullptr) != 0) {
+		git_buf_dispose(&buf);
+		return false;
+	}
+	out_git_dir = buf.ptr ? string(buf.ptr) : string();
+	git_buf_dispose(&buf);
+	return true;
+}
+
+// Splits `path` off the last component, in place.
+static string SplitLastComponent(const string &path) {
+	size_t slash = path.find_last_of('/');
+	return (slash == string::npos) ? path : path.substr(slash + 1);
+}
+
+// Give the location of `input` inside its repository, without ever comparing the
+// caller's spelling of a path against libgit2's.
+//
+// The two need not agree textually. libgit2 resolves symlinks, and on Windows
+// also drive-letter case, 8.3 short names, directory junctions, `subst` and
+// mapped network drives, and `\\?\` extended-length prefixes. GitPath::Parse
+// derived the in-repository path by stripping libgit2's repository root off the
+// front of the input as text, and when that prefix did not match it fell back to
+// treating the WHOLE input as a path filter inside the repository. Such a filter
+// matches nothing, so the query returned zero rows and no error -- and an empty
+// result is data, indistinguishable from an empty file or a repository with no
+// history (#38).
+//
+// Walking up from the input with git_repository_discover and watching for the
+// discovered .git directory to change locates the repository root in the
+// caller's own spelling, so the remainder can be taken from the input itself and
+// no text from libgit2 enters the comparison.
+//
+// `input` must be lexically absolute, and `expected_git_dir` the .git directory
+// of the repository the caller already resolved it to. Returns false when
+// `input` is not inside a repository at all, or lands in a DIFFERENT one than
+// the caller resolved -- the two can disagree, because ".." is resolved
+// lexically here but by the kernel during discovery, and across a symlink those
+// give different directories. Placing the input in a repository other than the
+// one about to be opened would produce exactly the silent empty result this
+// function exists to prevent, so the caller must report it instead.
+static bool RepoRelativePath(const string &input, const string &expected_git_dir, string &out_relative) {
+	// Split into the deepest existing directory and a remainder. The remainder
+	// may name something that exists only in history, which cannot be probed on
+	// disk and does not need to be.
+	string dir = input;
+	string remainder;
+	while (!dir.empty() && dir != "/" && !IsDirectory(dir)) {
+		string leaf = SplitLastComponent(dir);
+		if (!leaf.empty() && leaf != ".") {
+			remainder = remainder.empty() ? leaf : leaf + "/" + remainder;
+		}
+		string parent = GetParentDirectory(dir);
+		if (parent.empty() || parent == dir) {
+			return false;
+		}
+		dir = parent;
+	}
+
+	string anchor;
+	if (!DiscoverGitDir(dir, anchor) || anchor != expected_git_dir) {
+		return false;
+	}
+
+	vector<string> components;
+	string current = dir;
+	while (true) {
+		string parent = GetParentDirectory(current);
+		if (parent.empty() || parent == current) {
+			break;
+		}
+		string parent_anchor;
+		if (!DiscoverGitDir(parent, parent_anchor) || parent_anchor != anchor) {
+			// The parent belongs to a different repository, or none: `current` is
+			// the repository root, spelled the way the caller spelled it.
+			break;
+		}
+		string leaf = SplitLastComponent(current);
+		if (!leaf.empty() && leaf != ".") {
+			components.push_back(leaf);
+		}
+		current = parent;
+	}
+
+	out_relative.clear();
+	for (size_t i = components.size(); i > 0; i--) {
+		if (!out_relative.empty()) {
+			out_relative += "/";
+		}
+		out_relative += components[i - 1];
+	}
+	if (!remainder.empty()) {
+		if (!out_relative.empty()) {
+			out_relative += "/";
+		}
+		out_relative += remainder;
+	}
+	return true;
+}
+
 //===--------------------------------------------------------------------===//
 // Revision / path-suffix splitting
 //===--------------------------------------------------------------------===//
@@ -193,8 +307,28 @@ GitPath GitPath::Parse(const string &git_url) {
 					    normalized_url.substr(0, repo_prefix.length()) == repo_prefix) {
 						result.file_path = normalized_url.substr(repo_prefix.length()) + path_suffix;
 					} else {
-						// Use original relative path if normalized doesn't match
-						result.file_path = url + path_suffix;
+						// The input's spelling is not a textual prefix of libgit2's
+						// resolved repository root. Falling back to `url` here made the
+						// whole input a path filter inside the repository, which matched
+						// nothing: zero rows, no error, and no way for the caller to tell
+						// that from an empty file or an empty history (#38). Ask the
+						// repository where the input actually sits instead, and refuse to
+						// answer at all when even that cannot place it.
+						string relative;
+						string expected_git_dir;
+						if (!DiscoverGitDir(result.repository_path, expected_git_dir) ||
+						    !RepoRelativePath(normalized_url, expected_git_dir, relative)) {
+							throw IOException("Path '%s' was resolved to repository '%s', but its location inside that "
+							                  "repository could not be determined. Refusing to answer with an empty "
+							                  "result, which would be indistinguishable from a genuine one.",
+							                  git_url, result.repository_path);
+						}
+						if (relative.empty()) {
+							// The input names the repository root itself.
+							result.file_path = path_suffix.empty() ? "" : path_suffix.substr(1);
+						} else {
+							result.file_path = relative + path_suffix;
+						}
 					}
 				}
 			}

--- a/test/fixtures/setup_fixtures.sh
+++ b/test/fixtures/setup_fixtures.sh
@@ -81,6 +81,19 @@ setup_fixtures() {
     echo "Generating slash-bearing ref fixture..."
     bash "$FIXTURES_DIR/../scripts/setup_slash_refs_fixture.sh" "$TEMP_DIR"
 
+    # A second spelling of main-repo whose textual form differs from the one
+    # libgit2 resolves it to. GitPath::Parse derived the in-repository path by
+    # stripping libgit2's repository root off the input as text, so an input that
+    # did not match textually was reinterpreted as a path filter INSIDE the
+    # repository, matched nothing, and returned zero rows with no error (#38).
+    # A symlink is the portable way to build that mismatch on Unix; on Windows,
+    # drive-letter case, 8.3 short names, junctions and subst drives produce it
+    # just as readily, but this line is not portable there, so the tests that use
+    # this fixture are marked `require notwindows`.
+    echo "Linking symlinked-repo -> main-repo (differing path spelling)..."
+    ln -sfn "$TEMP_DIR/main-repo" "$TEMP_DIR/symlinked-repo" 2>/dev/null \
+        || echo "  warning: could not create symlink; the #38 regression tests will fail here"
+
     # A directory whose .git is present but unreadable to libgit2 -- a `.git`
     # file (the form submodules and worktrees use) with contents that are not
     # "gitdir: <path>". Discovery fails with GIT_ERROR, not GIT_ENOTFOUND, and

--- a/test/sql/git_path_spelling.test
+++ b/test/sql/git_path_spelling.test
@@ -1,0 +1,113 @@
+# name: test/sql/git_path_spelling.test
+# description: a path spelled differently from libgit2's resolution of it must still resolve (issue #38)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/repository';
+
+statement ok
+PRAGMA threads=1;
+
+# test/tmp/symlinked-repo is a symlink to test/tmp/main-repo, so libgit2
+# resolves it to a path that does not match the input textually. GitPath::Parse
+# derived the in-repository path by stripping libgit2's repository root off the
+# input as text; when that prefix did not match it fell back to treating the
+# WHOLE input as a path filter inside the repository. Such a filter matches
+# nothing, so every query below returned zero rows and no error -- and an empty
+# result is indistinguishable from an empty file or an empty history.
+#
+# On Windows the same mismatch arises without any symlink: drive-letter case,
+# 8.3 short names, directory junctions, subst and mapped network drives, and
+# \\?\ extended-length prefixes all produce it.
+#
+# main-repo has 3 commits, 4 tree entries at HEAD, 3 branches and 3 tags.
+
+query I
+SELECT COUNT(*) FROM git_log('test/tmp/symlinked-repo');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_tree('test/tmp/symlinked-repo');
+----
+4
+
+query I
+SELECT COUNT(*) FROM git_tags('test/tmp/symlinked-repo');
+----
+3
+
+# The two spellings must agree on every surface, not merely both be non-empty.
+query I
+SELECT (SELECT COUNT(*) FROM git_log('test/tmp/symlinked-repo')) =
+       (SELECT COUNT(*) FROM git_log('test/tmp/main-repo'));
+----
+true
+
+query I
+SELECT (SELECT COUNT(*) FROM git_tree('test/tmp/symlinked-repo')) =
+       (SELECT COUNT(*) FROM git_tree('test/tmp/main-repo'));
+----
+true
+
+# A path INSIDE the repository, reached through the differing spelling, must
+# name the same file rather than a filter that matches nothing.
+query I
+SELECT (SELECT COUNT(*) FROM git_log('test/tmp/symlinked-repo/README.md')) =
+       (SELECT COUNT(*) FROM git_log('test/tmp/main-repo/README.md'));
+----
+true
+
+query I
+SELECT COUNT(*) > 0 FROM git_log('test/tmp/symlinked-repo/README.md');
+----
+true
+
+# Reading content through the differing spelling must return the file, not an
+# empty string -- read_text returning "" is the case a caller cannot tell from
+# a genuinely empty file.
+query I
+SELECT (SELECT text FROM git_read('git://test/tmp/symlinked-repo/README.md@HEAD')) =
+       (SELECT text FROM git_read('git://test/tmp/main-repo/README.md@HEAD'));
+----
+true
+
+query I
+SELECT LENGTH(text) > 0 FROM git_read('git://test/tmp/symlinked-repo/README.md@HEAD');
+----
+true
+
+# A git:// URI carrying a revision must resolve through the differing spelling too.
+query I
+SELECT COUNT(*) FROM git_tree('git://test/tmp/symlinked-repo@v1.0.0');
+----
+4
+
+# Spellings that were already fine must stay fine.
+query I
+SELECT (SELECT COUNT(*) FROM git_log('test/tmp/main-repo/')) =
+       (SELECT COUNT(*) FROM git_log('test/tmp/main-repo'));
+----
+true
+
+query I
+SELECT (SELECT COUNT(*) FROM git_log('test/tmp/../tmp/main-repo')) =
+       (SELECT COUNT(*) FROM git_log('test/tmp/main-repo'));
+----
+true
+
+query I
+SELECT (SELECT COUNT(*) FROM git_log('./test/tmp/main-repo')) =
+       (SELECT COUNT(*) FROM git_log('test/tmp/main-repo'));
+----
+true
+
+# A path that names no repository at all must still raise rather than answer.
+statement error
+SELECT * FROM git_log('/nonexistent-top-level-directory-for-duck-tails/repo');
+----
+No git repository found for path


### PR DESCRIPTION
## Title

fix: locate a path inside its repository without comparing spellings (#38)

**Branch:** `fix/38-path-spelling` → `main`
**Head:** `bd9afdb8c644bb174fabbc620a2c5a5b72feda5a`
**Base:** stacked on `fix/42-discovery-error-reporting` — merge that one first, or set this PR's base to it.
**Closes:** #38

---

`GitPath::Parse` derived the in-repository path by stripping libgit2's resolved repository root off the front of the input **as text**. When that prefix did not match it fell back to

```cpp
// Use original relative path if normalized doesn't match
result.file_path = url + path_suffix;
```

which turns the whole input into a path filter *inside* the repository. Such a filter matches nothing, so the query returns **zero rows and no error** — and an empty result is data, indistinguishable from an empty file, an empty history, or simply no matching commits. Nothing indicated the path had been reinterpreted.

The two spellings need not agree: libgit2 resolves symlinks, and on Windows also drive-letter case, 8.3 short names, directory junctions, `subst` and mapped network drives, and `\\?\` prefixes. That is why Windows users meet this constantly, and why it is a candidate for the first symptom in #28.

## The queries that returned a wrong answer

`test/tmp/symlinked-repo` is a symlink to `test/tmp/main-repo` (3 commits, 4 tree entries, README.md 41 bytes):

| query | before | after |
|---|---|---|
| `SELECT count(*) FROM git_log('test/tmp/symlinked-repo')` | **0** | 3 |
| `SELECT count(*) FROM git_tree('test/tmp/symlinked-repo')` | **0** | 4 |
| `SELECT length(text) FROM git_read('git://test/tmp/symlinked-repo/README.md@HEAD')` | raised `file not found 'test/tmp/symlinked-repo/README.md' in commit 'HEAD'` (also untrue) | 41 |
| `SELECT count(*) FROM git_log('test/tmp/main-repo')` (control) | 3 | 3 |

## Approach

`RepoRelativePath` walks up from the input with `git_repository_discover` and watches for the discovered `.git` directory to change. That locates the repository root **in the caller's own spelling**, so the remainder is taken from the input itself and no text from libgit2 enters the comparison. It needs no platform-specific canonicalization, which matters for the Windows spellings that cannot be tested here.

It also refuses to guess: if the input cannot be placed, or lands in a *different* repository than discovery resolved (possible because `..` is resolved lexically here but by the kernel during discovery, and across a symlink those disagree), `Parse` raises instead of answering. Returning an empty result there is precisely the failure being fixed.

Only the previously-broken fallback changes. Every spelling that already worked takes the same branch it did before; the test pins `./x`, trailing-slash and `..` spellings to confirm that.

## Why it is stacked on #42

The new "cannot place this path" error is raised from inside the block that #42's catch-all used to wrap. Without #42 it would be swallowed and rewritten as "found no .git directory" — the wrong error, and the same class of misdirection. #42 is a standalone fix in its own right; this one needs it.

## Verification

- `make release && make test` on this branch: **1020 assertions in 61 test cases, all passed** (baseline `main`: 995 in 59).
- `make format-check`: passes.
- New `test/sql/git_path_spelling.test` (16 assertions). It compares each surface through both spellings rather than merely asserting non-empty, so a future regression fails instead of returning a plausible answer.
- `test/fixtures/setup_fixtures.sh` creates the symlink; the tests are `require notwindows` because that line is not portable, though the *bug* very much is.
