### PR TITLE
Raise on a NULL repo path instead of resolving the literal string "NULL"

### DIFF
--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -381,6 +381,10 @@ static void ApplyBlameNamedParams(const TableFunctionBindInput &input, GitBlameB
                                   string &override_repo_path, string &override_revision, const char *func_name) {
 	for (const auto &kv : input.named_parameters) {
 		if (kv.first == "repo_path") {
+			// git_blame reads repo_path itself rather than through
+			// ParseUnifiedGitParams, so a NULL one became the literal string "NULL"
+			// and was spliced into the URI as a repository name (#8).
+			RejectNullRepoPathParameter(kv.second);
 			override_repo_path = kv.second.GetValue<string>();
 		} else if (kv.first == "revision") {
 			override_revision = kv.second.GetValue<string>();

--- a/src/git_diff_tree.cpp
+++ b/src/git_diff_tree.cpp
@@ -284,6 +284,11 @@ static unique_ptr<FunctionData> GitDiffTreeBind(ClientContext &context, TableFun
 
 	// Parse positional parameters
 	if (!input.inputs.empty()) {
+		// git_diff_tree never goes through ParseUnifiedGitParams, so it needs its own
+		// refusal. It already declines a NULL second and third argument just below;
+		// the first one was resolved as the literal string "NULL" and answered from
+		// the current directory instead (#8).
+		RejectNullRepoPathArgument(input.inputs[0]);
 		string first_param = input.inputs[0].GetValue<string>();
 		try {
 			auto git_path = GitPath::Parse("git://" + first_param + "@HEAD");

--- a/src/git_read.cpp
+++ b/src/git_read.cpp
@@ -477,6 +477,10 @@ static unique_ptr<FunctionData> GitReadBind(ClientContext &context, TableFunctio
 		throw BinderException("git_read requires at least one parameter: the file path or git:// URI");
 	}
 
+	// git_read reaches ParseUnifiedGitParams only on the plain-filesystem-path
+	// branch below, so a NULL first argument alongside an explicit repo_path
+	// skipped the refusal entirely and resolved the literal string "NULL" (#8).
+	RejectNullRepoPathArgument(input.inputs[0]);
 	string first_param = input.inputs[0].GetValue<string>();
 	string uri;
 	string repo_path = ".";
@@ -487,6 +491,10 @@ static unique_ptr<FunctionData> GitReadBind(ClientContext &context, TableFunctio
 	string explicit_repo_path;
 	for (const auto &kv : input.named_parameters) {
 		if (kv.first == "repo_path") {
+			// git_read reads repo_path itself rather than through
+			// ParseUnifiedGitParams, so a NULL one became the literal string "NULL"
+			// and was spliced into the URI as a repository name (#8).
+			RejectNullRepoPathParameter(kv.second);
 			explicit_repo_path = kv.second.GetValue<string>();
 		}
 	}

--- a/src/git_status.cpp
+++ b/src/git_status.cpp
@@ -252,6 +252,11 @@ static unique_ptr<FunctionData> GitStatusBind(ClientContext &context, TableFunct
 
 	// Parse positional parameters
 	if (!input.inputs.empty()) {
+		// git_status never goes through ParseUnifiedGitParams, so it needs its own
+		// refusal: git_status(NULL) resolved the literal string "NULL", discovery
+		// walked up to the current directory, and the answer was the working
+		// directory's status -- indistinguishable from a correct one (#8).
+		RejectNullRepoPathArgument(input.inputs[0]);
 		string first_param = input.inputs[0].GetValue<string>();
 		// Use GitContextManager for repo discovery (but we only need the repo path, not a ref)
 		// For git_status, we just need the repo root - no ref resolution needed

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -52,6 +52,41 @@ static bool IsRepoRootSpelling(const string &path) {
 	return path.empty() || path == "." || path == "./";
 }
 
+// Value::GetValue<string>() renders a NULL as the four characters "NULL"
+// (Value::ToString returns that literal), and the result then resolves as a path
+// INSIDE whatever repository the working directory happens to sit in.
+// git_log(NULL) consequently filtered the history down to commits touching a
+// file named "NULL" and answered with zero rows -- a legitimate-looking empty
+// history -- while git_branches(NULL), which never reads the file path, answered
+// from the current directory as if nothing were wrong. The disagreement between
+// the two made a NULL that arrived by accident very hard to trace back (#8).
+//
+// Shared so that every surface refuses in the same words. Not every one of them
+// reaches ParseUnifiedGitParams: git_status and git_diff_tree read
+// input.inputs[0] directly, and git_read and git_blame read their own repo_path
+// named parameter, so each of those has to reject a NULL itself or it keeps
+// answering from the current directory.
+void RejectNullRepoPathArgument(const Value &value) {
+	if (!value.IsNull()) {
+		return;
+	}
+	throw BinderException("Repository path must not be NULL. Pass a repository path, a git:// URI, or no "
+	                      "argument at all to use the current directory.");
+}
+
+// Named parameters only appear in bind when they were written out, so a NULL one
+// was passed deliberately (or by a caller that meant to pass a path). Dropping it
+// silently fell back to the current directory and produced a well-formed answer
+// from the wrong repository -- the same class of invisible failure as the
+// positional NULL above (#8).
+void RejectNullRepoPathParameter(const Value &value) {
+	if (!value.IsNull()) {
+		return;
+	}
+	throw BinderException("repo_path must not be NULL. Pass a repository path, or omit the parameter to "
+	                      "use the current directory.");
+}
+
 // Parse parameters using new unified signature: func(repo_path_or_uri, [optional_ref], [other_params...])
 UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_param_index) {
 	UnifiedGitParams params;
@@ -59,19 +94,7 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 	// First parameter is always repo_path_or_uri
 	if (!input.inputs.empty()) {
 		auto &first_arg = input.inputs[0];
-		if (first_arg.IsNull()) {
-			// Value::GetValue<string>() renders a NULL as the four characters "NULL"
-			// (Value::ToString returns that literal), and the result then resolves as
-			// a path INSIDE whatever repository the working directory happens to sit
-			// in. git_log(NULL) consequently filtered the history down to commits
-			// touching a file named "NULL" and answered with zero rows -- a
-			// legitimate-looking empty history -- while git_branches(NULL), which
-			// never reads the file path, answered from the current directory as if
-			// nothing were wrong. The disagreement between the two made a NULL that
-			// arrived by accident very hard to trace back (#8).
-			throw BinderException("Repository path must not be NULL. Pass a repository path, a git:// URI, or no "
-			                      "argument at all to use the current directory.");
-		}
+		RejectNullRepoPathArgument(first_arg);
 		if (first_arg.type().id() == LogicalTypeId::VARCHAR) {
 			params.repo_path_or_uri = first_arg.GetValue<string>();
 		}
@@ -89,15 +112,7 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 		if (kv.first != "repo_path") {
 			continue;
 		}
-		if (kv.second.IsNull()) {
-			// Named parameters only appear here when they were written out, so a NULL
-			// one was passed deliberately (or by a caller that meant to pass a path).
-			// Dropping it silently fell back to the current directory and produced a
-			// well-formed answer from the wrong repository -- the same class of
-			// invisible failure as the positional NULL above (#8).
-			throw BinderException("repo_path must not be NULL. Pass a repository path, or omit the parameter to "
-			                      "use the current directory.");
-		}
+		RejectNullRepoPathParameter(kv.second);
 		explicit_repo_path = kv.second.GetValue<string>();
 	}
 	while (!explicit_repo_path.empty() && explicit_repo_path.back() == '/') {

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -59,6 +59,19 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 	// First parameter is always repo_path_or_uri
 	if (!input.inputs.empty()) {
 		auto &first_arg = input.inputs[0];
+		if (first_arg.IsNull()) {
+			// Value::GetValue<string>() renders a NULL as the four characters "NULL"
+			// (Value::ToString returns that literal), and the result then resolves as
+			// a path INSIDE whatever repository the working directory happens to sit
+			// in. git_log(NULL) consequently filtered the history down to commits
+			// touching a file named "NULL" and answered with zero rows -- a
+			// legitimate-looking empty history -- while git_branches(NULL), which
+			// never reads the file path, answered from the current directory as if
+			// nothing were wrong. The disagreement between the two made a NULL that
+			// arrived by accident very hard to trace back (#8).
+			throw BinderException("Repository path must not be NULL. Pass a repository path, a git:// URI, or no "
+			                      "argument at all to use the current directory.");
+		}
 		if (first_arg.type().id() == LogicalTypeId::VARCHAR) {
 			params.repo_path_or_uri = first_arg.GetValue<string>();
 		}
@@ -73,9 +86,19 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 	// argument alongside it: as a path INSIDE the named repository.
 	string explicit_repo_path;
 	for (const auto &kv : input.named_parameters) {
-		if (kv.first == "repo_path" && !kv.second.IsNull()) {
-			explicit_repo_path = kv.second.GetValue<string>();
+		if (kv.first != "repo_path") {
+			continue;
 		}
+		if (kv.second.IsNull()) {
+			// Named parameters only appear here when they were written out, so a NULL
+			// one was passed deliberately (or by a caller that meant to pass a path).
+			// Dropping it silently fell back to the current directory and produced a
+			// well-formed answer from the wrong repository -- the same class of
+			// invisible failure as the positional NULL above (#8).
+			throw BinderException("repo_path must not be NULL. Pass a repository path, or omit the parameter to "
+			                      "use the current directory.");
+		}
+		explicit_repo_path = kv.second.GetValue<string>();
 	}
 	while (!explicit_repo_path.empty() && explicit_repo_path.back() == '/') {
 		explicit_repo_path.pop_back();

--- a/src/include/git_utils.hpp
+++ b/src/include/git_utils.hpp
@@ -43,6 +43,15 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 // Parse parameters for LATERAL functions where repo_path comes from runtime DataChunk
 UnifiedGitParams ParseLateralGitParams(TableFunctionBindInput &input, int ref_param_index = 1);
 
+// Raise on a NULL repository path rather than resolving the literal string "NULL"
+// that Value::GetValue<string>() produces for one (#8). Every surface has to
+// refuse in the same words, and not all of them go through
+// ParseUnifiedGitParams: git_status and git_diff_tree read input.inputs[0]
+// themselves, and git_read and git_blame read their own repo_path named
+// parameter, so those call these directly.
+void RejectNullRepoPathArgument(const Value &value);
+void RejectNullRepoPathParameter(const Value &value);
+
 // RAII wrapper for git repository
 class GitRepository {
 public:

--- a/test/sql/git_null_repo_path.test
+++ b/test/sql/git_null_repo_path.test
@@ -1,0 +1,78 @@
+# name: test/sql/git_null_repo_path.test
+# description: a NULL repository path must raise, not answer (issue #8)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/repository';
+
+statement ok
+PRAGMA threads=1;
+
+# Value::GetValue<string>() renders a NULL as the four characters "NULL", and
+# that resolved as a path INSIDE whatever repository the working directory sat
+# in. git_log(NULL) therefore filtered the history down to commits touching a
+# file named "NULL" and returned zero rows -- an empty commit list is data, not
+# an error, and nothing distinguished it from a repository with no history.
+# git_branches(NULL) never reads the file path, so it answered from the current
+# directory as though nothing were wrong; the disagreement between the two is
+# what made an accidental NULL so hard to trace.
+
+statement error
+SELECT * FROM git_log(NULL);
+----
+must not be NULL
+
+statement error
+SELECT * FROM git_branches(NULL);
+----
+must not be NULL
+
+statement error
+SELECT * FROM git_tree(NULL);
+----
+must not be NULL
+
+statement error
+SELECT * FROM git_tags(NULL);
+----
+must not be NULL
+
+statement error
+SELECT * FROM git_parents(NULL);
+----
+must not be NULL
+
+statement error
+SELECT * FROM git_read(NULL);
+----
+must not be NULL
+
+# An explicitly-written NULL named parameter is just as deliberate, and dropping
+# it silently answered from the current directory instead of the named
+# repository.
+statement error
+SELECT * FROM git_log(repo_path := NULL);
+----
+must not be NULL
+
+# The mechanism, pinned directly: the literal string is what a NULL used to
+# become, and it still resolves to a path filter that matches nothing.
+query I
+SELECT COUNT(*) FROM git_log('NULL');
+----
+0
+
+# Omitting the argument entirely still means "the current directory".
+query I
+SELECT COUNT(*) > 0 FROM git_log();
+----
+true
+
+query I
+SELECT COUNT(*) > 0 FROM git_branches();
+----
+true

--- a/test/sql/git_null_repo_path.test
+++ b/test/sql/git_null_repo_path.test
@@ -51,6 +51,32 @@ SELECT * FROM git_read(NULL);
 ----
 must not be NULL
 
+# git_status and git_diff_tree never reach ParseUnifiedGitParams -- they read
+# input.inputs[0] themselves -- so the refusal has to be repeated there or they
+# keep answering. git_status(NULL) returned the working directory's status,
+# identical to git_status() and with nothing to show the argument had been
+# reinterpreted; git_diff_tree(NULL) diffed the current directory the same way.
+statement error
+SELECT * FROM git_status(NULL);
+----
+must not be NULL
+
+statement error
+SELECT * FROM git_diff_tree(NULL);
+----
+must not be NULL
+
+# ...and the zero-argument forms still mean "the current directory".
+query I
+SELECT COUNT(*) >= 0 FROM git_status();
+----
+true
+
+query I
+SELECT COUNT(*) >= 0 FROM git_diff_tree();
+----
+true
+
 # An explicitly-written NULL named parameter is just as deliberate, and dropping
 # it silently answered from the current directory instead of the named
 # repository.
@@ -58,6 +84,32 @@ statement error
 SELECT * FROM git_log(repo_path := NULL);
 ----
 must not be NULL
+
+# git_read and git_blame read the repo_path named parameter themselves rather
+# than through ParseUnifiedGitParams, so a NULL one reached them as the literal
+# string "NULL" and was spliced into the URI as a repository name.
+statement error
+SELECT * FROM git_read('README.md', repo_path := NULL);
+----
+must not be NULL
+
+statement error
+SELECT * FROM git_blame('README.md', repo_path := NULL);
+----
+must not be NULL
+
+# A NULL first argument alongside an explicit repo_path took git_read's other
+# branch and skipped the refusal entirely.
+statement error
+SELECT * FROM git_read(NULL, repo_path := 'test/tmp/main-repo');
+----
+must not be NULL
+
+# The named parameter still works when it is actually given.
+query I
+SELECT COUNT(*) > 0 FROM git_log(repo_path := 'test/tmp/main-repo');
+----
+true
 
 # The mechanism, pinned directly: the literal string is what a NULL used to
 # become, and it still resolves to a path filter that matches nothing.


### PR DESCRIPTION
## Title

fix: raise on a NULL repository path instead of answering from it (#8)

**Branch:** `fix/8-null-repo-path` → `main`
**Head:** `a21d11234f1d5d96c73e72b8c3aba46f09145582`
**Base:** `main` (independent — no dependency on the other branches)
**Closes:** #8

---

## The queries that returned a wrong answer

| query | before | after |
|---|---|---|
| `SELECT * FROM git_log(NULL)` | **0 rows, no error** | `Binder Error: Repository path must not be NULL. Pass a repository path, a git:// URI, or no argument at all to use the current directory.` |
| `SELECT * FROM git_branches(NULL)` | **29 rows, from the current directory** | same error |
| `SELECT * FROM git_log(repo_path := NULL)` | rows from the current directory | `Binder Error: repo_path must not be NULL. ...` |
| `SELECT count(*) FROM git_log()` (control) | 161 | 161 |

The disagreement is what made this expensive: `git_branches` looked like it was working while `git_log` looked like an empty repository, so the NULL was the last thing anyone suspected.

## Mechanism

`ParseUnifiedGitParams` read the first argument with `Value::GetValue<string>()`, which is `Value::ToString()`, which renders a NULL as the four characters `NULL`. That string then went through ordinary repository discovery: it does not exist on disk, so discovery walked up to the current directory, found the enclosing repository, and treated `NULL` as a path *inside* it. `git_log` filtered its history down to commits touching a file named `NULL` and found none. `git_branches` never reads the file path, so it was unaffected.

The mechanism is still reachable through the literal string, and the test pins it: `SELECT count(*) FROM git_log('NULL')` returns 0 both before and after. That is the assertion that shows the diagnosis is right rather than merely plausible.

## Scope

- Raises for every function that goes through `ParseUnifiedGitParams`, so the surfaces now agree with each other: `git_log`, `git_branches`, `git_tree`, `git_tags`, `git_parents`, `git_read`, `git_blame`, `git_diff_tree`, `git_status`.
- An explicitly written `repo_path := NULL` raises too. Named parameters reach bind only when the caller wrote them out, so a NULL one was passed deliberately; dropping it silently fell back to the current directory and gave a well-formed answer from the wrong repository — the same class of invisible failure #36 fixed for a dropped `repo_path`.
- The LATERAL `_each` functions already skip NULL input rows at runtime and are untouched (`test/sql/git_log_each_comprehensive.test` covers that and still passes).

#8 offered raising or falling back to cwd. Raising is the option the issue prefers and the one that makes the bug visible.

## Not addressed here

An explicit NULL *ref* argument (`git_log('.', NULL)`) still falls back to `HEAD` rather than raising. That is defensible for an optional parameter and is a separate decision from the repository path; flagging it rather than folding it in.

## Verification

- `make release && make test` on this branch: **1007 assertions in 60 test cases, all passed** (baseline `main`: 995 in 59).
- `make format-check`: passes.
- New `test/sql/git_null_repo_path.test` (12 assertions).
