### PR TITLE
Stop reporting open failures as parse failures; drop the nested escaping

### DIFF
--- a/src/git_branches.cpp
+++ b/src/git_branches.cpp
@@ -49,7 +49,7 @@ unique_ptr<FunctionData> GitBranchesBind(ClientContext &context, TableFunctionBi
 		final_ref = ctx.final_ref;
 		// ctx.repo and ctx.resolved_object are managed by GitContextManager
 	} catch (const std::exception &e) {
-		throw BinderException("git_branches: %s", e.what());
+		throw BinderException("git_branches: %s", GitExceptionMessage(e));
 	}
 
 	return_types = {

--- a/src/git_context_manager.cpp
+++ b/src/git_context_manager.cpp
@@ -1,4 +1,5 @@
 #include "git_context_manager.hpp"
+#include "git_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 
@@ -52,7 +53,7 @@ GitContextManager::GitContext GitContextManager::ProcessGitUri(const string &uri
 			git_path = GitPath::Parse(constructed_uri);
 		}
 	} catch (const std::exception &e) {
-		throw IOException("GitContextManager: Failed to parse URI '%s': %s", uri_or_path, e.what());
+		throw IOException("GitContextManager: Failed to parse URI '%s': %s", uri_or_path, GitExceptionMessage(e));
 	}
 
 	// Phase 2: Reference Resolution

--- a/src/git_diff_tree.cpp
+++ b/src/git_diff_tree.cpp
@@ -289,14 +289,15 @@ static unique_ptr<FunctionData> GitDiffTreeBind(ClientContext &context, TableFun
 			auto git_path = GitPath::Parse("git://" + first_param + "@HEAD");
 			repo_path = git_path.repository_path;
 		} catch (const std::exception &e) {
-			throw BinderException("git_diff_tree: failed to resolve repository path '%s': %s", first_param, e.what());
+			throw BinderException("git_diff_tree: failed to resolve repository path '%s': %s", first_param,
+			                      GitExceptionMessage(e));
 		}
 	} else {
 		try {
 			auto git_path = GitPath::Parse("git://.@HEAD");
 			repo_path = git_path.repository_path;
 		} catch (const std::exception &e) {
-			throw BinderException("git_diff_tree: failed to resolve repository: %s", e.what());
+			throw BinderException("git_diff_tree: failed to resolve repository: %s", GitExceptionMessage(e));
 		}
 	}
 

--- a/src/git_filesystem.cpp
+++ b/src/git_filesystem.cpp
@@ -409,15 +409,17 @@ unique_ptr<FileHandle> GitFileSystem::OpenFile(const string &path, FileOpenFlags
 				return make_uniq<GitFileHandle>(*this, path, content_ptr, flags);
 			}
 		} catch (const std::exception &e) {
-			throw IOException("Failed to open git file '%s': %s", path, e.what());
+			throw IOException("Failed to open git file '%s': %s", path, GitExceptionMessage(e));
 		}
-	} catch (const IOException &e) {
-		// Re-throw repository discovery errors directly without wrapping
-		string error_msg = e.what();
-		if (error_msg.find("No git repository found for path") != string::npos) {
-			throw;
-		}
-		throw IOException("Failed to parse git path '%s': %s", path, e.what());
+	} catch (const IOException &) {
+		// Every IOException GitPath::Parse raises already names the URI and the
+		// underlying cause, and the inner catch above has already named the path.
+		// Re-wrapping added a fourth "Failed to ..." layer that said nothing new
+		// and, before GitExceptionMessage, a fourth round of JSON escaping around
+		// the one message that mattered (#22).
+		throw;
+	} catch (const std::exception &e) {
+		throw IOException("Failed to parse git path '%s': %s", path, GitExceptionMessage(e));
 	}
 }
 
@@ -493,15 +495,17 @@ vector<OpenFileInfo> GitFileSystem::Glob(const string &pattern, FileOpener *open
 			return ListFiles(repo, git_path, commit_obj);
 
 		} catch (const std::exception &e) {
-			throw IOException("Failed to glob git pattern '%s': %s", pattern, e.what());
+			throw IOException("Failed to glob git pattern '%s': %s", pattern, GitExceptionMessage(e));
 		}
-	} catch (const IOException &e) {
-		// Re-throw repository discovery errors directly without wrapping
-		string error_msg = e.what();
-		if (error_msg.find("No git repository found for path") != string::npos) {
-			throw;
-		}
-		throw IOException("Failed to parse git path '%s': %s", pattern, e.what());
+	} catch (const IOException &) {
+		// Every IOException GitPath::Parse raises already names the URI and the
+		// underlying cause, and the inner catch above has already named the
+		// pattern. Re-wrapping added a fourth "Failed to ..." layer that said
+		// nothing new and, before GitExceptionMessage, a fourth round of JSON
+		// escaping around the one message that mattered (#22).
+		throw;
+	} catch (const std::exception &e) {
+		throw IOException("Failed to parse git path '%s': %s", pattern, GitExceptionMessage(e));
 	}
 }
 

--- a/src/git_log.cpp
+++ b/src/git_log.cpp
@@ -58,7 +58,7 @@ unique_ptr<FunctionData> GitLogBind(ClientContext &context, TableFunctionBindInp
 		result->ref = (ctx.ref_kind == RefKind::COMMIT) ? ctx.final_ref : "HEAD";
 		return std::move(result);
 	} catch (const std::exception &e) {
-		throw BinderException("git_log: %s", e.what());
+		throw BinderException("git_log: %s", GitExceptionMessage(e));
 	}
 }
 
@@ -346,7 +346,7 @@ static OperatorResultType GitLogEachFunction(ExecutionContext &context, TableFun
 				final_ref = ctx.final_ref;
 			} catch (const std::exception &e) {
 				// GitContextManager provides consistent error messages
-				throw BinderException("git_log_each: %s", e.what());
+				throw BinderException("git_log_each: %s", GitExceptionMessage(e));
 			}
 
 			// Check if we can reuse cached repository (optimization for LATERAL joins)

--- a/src/git_parents.cpp
+++ b/src/git_parents.cpp
@@ -73,7 +73,7 @@ unique_ptr<FunctionData> GitParentsBind(ClientContext &context, TableFunctionBin
 		final_ref = ctx.final_ref;
 		// file_path not needed for git_parents
 	} catch (const std::exception &e) {
-		throw BinderException("git_parents: %s", e.what());
+		throw BinderException("git_parents: %s", GitExceptionMessage(e));
 	}
 
 	// Use helper to define schema with repo_path as first column

--- a/src/git_read.cpp
+++ b/src/git_read.cpp
@@ -465,7 +465,7 @@ static void ProcessGitURI(const string &uri, const GitReadBindData &bind_data, G
 		git_repository_free(repo);
 
 	} catch (const std::exception &e) {
-		throw BinderException("git_read: %s", e.what());
+		throw BinderException("git_read: %s", GitExceptionMessage(e));
 	}
 }
 

--- a/src/git_status.cpp
+++ b/src/git_status.cpp
@@ -259,7 +259,8 @@ static unique_ptr<FunctionData> GitStatusBind(ClientContext &context, TableFunct
 			auto git_path = GitPath::Parse("git://" + first_param + "@HEAD");
 			repo_path = git_path.repository_path;
 		} catch (const std::exception &e) {
-			throw BinderException("git_status: failed to resolve repository path '%s': %s", first_param, e.what());
+			throw BinderException("git_status: failed to resolve repository path '%s': %s", first_param,
+			                      GitExceptionMessage(e));
 		}
 	} else {
 		// Zero-arg: discover repo from cwd
@@ -267,7 +268,7 @@ static unique_ptr<FunctionData> GitStatusBind(ClientContext &context, TableFunct
 			auto git_path = GitPath::Parse("git://.@HEAD");
 			repo_path = git_path.repository_path;
 		} catch (const std::exception &e) {
-			throw BinderException("git_status: failed to resolve repository: %s", e.what());
+			throw BinderException("git_status: failed to resolve repository: %s", GitExceptionMessage(e));
 		}
 	}
 

--- a/src/git_tags.cpp
+++ b/src/git_tags.cpp
@@ -77,7 +77,7 @@ unique_ptr<FunctionData> GitTagsBind(ClientContext &context, TableFunctionBindIn
 		auto ctx = GitContextManager::Instance().ProcessGitUri(params.repo_path_or_uri, params.ref);
 		return make_uniq<GitTagsFunctionData>(params.repo_path_or_uri, ctx.repo_path);
 	} catch (const std::exception &e) {
-		throw BinderException("git_tags: %s", e.what());
+		throw BinderException("git_tags: %s", GitExceptionMessage(e));
 	}
 }
 

--- a/src/git_tree.cpp
+++ b/src/git_tree.cpp
@@ -587,7 +587,7 @@ unique_ptr<FunctionData> GitTreeBind(ClientContext &context, TableFunctionBindIn
 		return std::move(result);
 
 	} catch (const std::exception &e) {
-		throw BinderException("git_tree: %s", e.what());
+		throw BinderException("git_tree: %s", GitExceptionMessage(e));
 	}
 }
 

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -3,6 +3,7 @@
 #include "git_context_manager.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/error_data.hpp"
 
 #ifdef _WIN32
 #include <stdlib.h> // _fullpath
@@ -12,6 +13,10 @@
 #endif
 
 namespace duckdb {
+
+string GitExceptionMessage(const std::exception &e) {
+	return ErrorData(e).RawMessage();
+}
 
 string ApplyExplicitRepoPath(const string &uri, const string &repo_path, const string &function_name) {
 	if (repo_path.empty() || !StringUtil::StartsWith(uri, "git://")) {
@@ -102,7 +107,8 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 			params.ref_kind = ctx.ref_kind;
 			params.has_embedded_ref = !ctx.final_ref.empty() && ctx.final_ref != "HEAD";
 		} catch (const std::exception &e) {
-			throw BinderException("Failed to parse git:// URI '%s': %s", params.repo_path_or_uri, e.what());
+			throw BinderException("Failed to parse git:// URI '%s': %s", params.repo_path_or_uri,
+			                      GitExceptionMessage(e));
 		}
 	} else {
 		// Filesystem path - use repository discovery
@@ -114,7 +120,8 @@ UnifiedGitParams ParseUnifiedGitParams(TableFunctionBindInput &input, int ref_pa
 			params.ref_kind = ctx.ref_kind;
 			params.has_embedded_ref = false;
 		} catch (const std::exception &e) {
-			throw BinderException("Failed to resolve repository path '%s': %s", params.repo_path_or_uri, e.what());
+			throw BinderException("Failed to resolve repository path '%s': %s", params.repo_path_or_uri,
+			                      GitExceptionMessage(e));
 		}
 	}
 

--- a/src/include/git_utils.hpp
+++ b/src/include/git_utils.hpp
@@ -12,6 +12,20 @@
 
 namespace duckdb {
 
+// Plain text of a caught exception, safe to embed in another exception message.
+//
+// A DuckDB exception carries its message as a JSON document -- Exception derives
+// from std::runtime_error constructed with Exception::ToJSON -- so what()
+// returns {"exception_type":"IO","exception_message":"..."}. Splicing that into
+// a new exception message JSON-encodes an already-encoded string, and when a
+// chain of layers each does so the escaping compounds: git_read -> git_open ->
+// git_parse -> git_lookup buried "the requested type does not match the type in
+// the ODB" under four rounds of backslashes, unreadable to users and agents
+// alike (#22). ErrorData parses the document back to the message it was built
+// from; anything that is not such a document -- a non-DuckDB exception -- passes
+// through unchanged.
+string GitExceptionMessage(const std::exception &e);
+
 // Unified parameters structure for git functions
 struct UnifiedGitParams {
 	string repo_path_or_uri;

--- a/src/text_diff.cpp
+++ b/src/text_diff.cpp
@@ -1,5 +1,6 @@
 #include "text_diff.hpp"
 #include "duckdb_compat.hpp"
+#include "git_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -226,7 +227,7 @@ static void DiffTextFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 		} catch (const std::exception &e) {
 			// Return error as string for now - full implementation would throw proper exceptions
-			string error_str = "Error: " + string(e.what());
+			string error_str = "Error: " + string(GitExceptionMessage(e));
 			result_data[i] = StringVector::AddString(result, error_str);
 		}
 	}
@@ -392,7 +393,7 @@ static unique_ptr<GlobalTableFunctionState> ReadGitDiffInit(ClientContext &conte
 			file_handle1->Close();
 			content1 = string(reinterpret_cast<const char *>(buffer1.get()), file_size1);
 		} catch (const std::exception &e) {
-			throw IOException("Failed to read file '%s': %s", path1, e.what());
+			throw IOException("Failed to read file '%s': %s", path1, GitExceptionMessage(e));
 		}
 
 		// Read second file
@@ -404,7 +405,7 @@ static unique_ptr<GlobalTableFunctionState> ReadGitDiffInit(ClientContext &conte
 			file_handle2->Close();
 			content2 = string(reinterpret_cast<const char *>(buffer2.get()), file_size2);
 		} catch (const std::exception &e) {
-			throw IOException("Failed to read file '%s': %s", path2, e.what());
+			throw IOException("Failed to read file '%s': %s", path2, GitExceptionMessage(e));
 		}
 
 		// Create diff using our TextDiff implementation
@@ -415,7 +416,7 @@ static unique_ptr<GlobalTableFunctionState> ReadGitDiffInit(ClientContext &conte
 
 	} catch (const std::exception &e) {
 		// Return error in diff_text for now
-		string error_diff = "Error: " + string(e.what());
+		string error_diff = "Error: " + string(GitExceptionMessage(e));
 		return make_uniq<ReadGitDiffData>(std::move(error_diff), path1, path2, bind_data.include_metadata);
 	}
 }

--- a/test/sql/git_error_messages.test
+++ b/test/sql/git_error_messages.test
@@ -1,0 +1,76 @@
+# name: test/sql/git_error_messages.test
+# description: layered git errors must not accumulate JSON escaping (issue #22)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/repository';
+
+statement ok
+PRAGMA threads=1;
+
+# A DuckDB exception carries its message as a JSON document, so what() returns
+# {"exception_type":...,"exception_message":...}. Splicing that into a new
+# exception message re-encodes an already-encoded string, and with several
+# layers each doing so the escaping compounds:
+#
+#   {"exception_type":"IO","exception_message":"Failed to read file '...':
+#    {\"exception_type\":\"IO\",\"exception_message\":\"Failed to parse git path
+#    '...': {\\\"exception_type\\\" ... }}
+#
+# The one line that mattered -- libgit2's own diagnosis -- sat under four rounds
+# of backslashes, unreadable to users and agents alike.
+
+# read_git_diff reports a failure in its diff_text column rather than raising,
+# which makes the message directly assertable as data.
+query I
+SELECT diff_text NOT LIKE '%exception_type%'
+FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
+                   'git://test/tmp/main-repo/README.md@HEAD');
+----
+true
+
+query I
+SELECT diff_text NOT LIKE '%\\%'
+FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
+                   'git://test/tmp/main-repo/README.md@HEAD');
+----
+true
+
+# The innermost cause -- the only part a reader needs -- must survive to the top.
+query I
+SELECT diff_text LIKE '%revspec ''nosuchref'' not found%'
+FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
+                   'git://test/tmp/main-repo/README.md@HEAD');
+----
+true
+
+# The same, for errors that are raised rather than returned. <!REGEX> asserts
+# the message nowhere carries a re-encoded exception document.
+statement error
+SELECT * FROM read_csv('git://test/tmp/main-repo/README.md@nosuchref');
+----
+<!REGEX>:(?s).*exception_type.*
+
+statement error
+SELECT * FROM read_csv('git://test/tmp/main-repo/README.md@nosuchref');
+----
+revspec 'nosuchref' not found
+
+statement error
+SELECT * FROM read_text('git://test/tmp/main-repo/README.md@nosuchref');
+----
+<!REGEX>:(?s).*exception_type.*
+
+statement error
+SELECT * FROM git_log('/nonexistent-top-level-directory-for-duck-tails/repo');
+----
+<!REGEX>:(?s).*exception_type.*
+
+statement error
+SELECT * FROM git_log('/nonexistent-top-level-directory-for-duck-tails/repo');
+----
+No git repository found for path


### PR DESCRIPTION
## Title

fix: stop re-encoding exception messages at every layer (#22)

**Branch:** `fix/22-error-message-nesting` → `main`
**Head:** `0ca4c07a4eee9e7c2343dacc06b0d93518200b03`
**Base:** `main` (independent; merges cleanly with the other branches — verified)
**Closes:** #22

---

A DuckDB exception carries its message as a JSON document — `Exception` derives from `std::runtime_error` constructed with `Exception::ToJSON` — so `what()` returns `{"exception_type":...,"exception_message":...}`. Splicing that into a new exception message JSON-encodes an already-encoded string, and with a chain of layers each doing so the escaping compounds.

## Before / after, on the reproduction from the issue

```sql
SELECT * FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
                            'git://test/tmp/main-repo/README.md@HEAD');
```

**before**
```
Error: {"exception_type":"IO","exception_message":"Failed to read file '...':
{\"exception_type\":\"IO\",\"exception_message\":\"Failed to parse git path '...':
{\\\"exception_type\\\":\\\"IO\\\",\\\"exception_message\\\":\\\"Failed to open git
file '...': {\\\\\\\"exception_type\\\\\\\":\\\\\\\"IO\\\\\\\",\\\\\\\"exception_message
\\\\\\\":\\\\\\\"Failed to resolve revision 'nosuchref': revspec 'nosuchref' not
found\\\\\\\"}\\\"}\"}"}
```

**after**
```
Error: Failed to read file 'git://test/tmp/main-repo/README.md@nosuchref':
Failed to open git file 'git://test/tmp/main-repo/README.md@nosuchref':
Failed to resolve revision 'nosuchref': revspec 'nosuchref' not found
```

## What changed

`GitExceptionMessage(e)` returns `ErrorData(e).RawMessage()`, which parses the document back to the message it was built from; a non-DuckDB exception passes through unchanged. Every site that spliced `e.what()` into a new message now goes through it (24 sites across 12 files), so no layer re-encodes and the escaping cannot accumulate however deep the chain gets. That is option 2 from the issue, applied uniformly rather than at the top only.

Two layers are also **dropped**. `GitFileSystem::OpenFile` and `::Glob` caught `IOException` around the whole body and re-wrapped it as `Failed to parse git path '<path>'`, which

- added nothing — the inner catch had already named the path, and
- **misdescribed the failure**: parsing had succeeded; it was the open that failed.

They now re-throw an `IOException` unchanged and wrap only the non-`IOException` case, which is the one that still needs the path attached. No test matched those strings.

## Verification

- `make release && make test` on this branch: **1005 assertions in 60 test cases, all passed** (baseline `main`: 995 in 59).
- `make format-check`: passes.
- New `test/sql/git_error_messages.test` (10 assertions). It asserts the innermost cause survives to the top, and uses `<!REGEX>` to assert no re-encoded exception document appears anywhere in the message — including on the `read_git_diff` path, which reports into its `diff_text` column and so can be asserted as ordinary data.
