### PR TITLE
Restore large_dataset.csv from its recorded oid; remove the stale gitattributes rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-# Git LFS configuration for test files
-test/data/large_dataset.csv filter=lfs diff=lfs merge=lfs -text
-test/data/evolving_dataset.csv filter=lfs diff=lfs merge=lfs -text

--- a/test/data/large_dataset.csv
+++ b/test/data/large_dataset.csv
@@ -1,3 +1,4 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b01458781eb3e9e62a095df408735c635e6b61a75eeb86c7662476b94bc52291
-size 30
+id,name,value
+1,Test,100
+2,LFS,200
+3,Data,300


### PR DESCRIPTION
## Title

fix: commit test/data/large_dataset.csv directly instead of through LFS (#43)

**Branch:** `fix/43-lfs-fixture` → `main`
**Head:** `39124693f26bf1fbb4d5ee3cde65d8c697a26a8a`
**Base:** `main` (independent)
**Closes:** #43

---

A fresh clone or `git worktree add` dies in the smudge filter: the LFS object `b0145878` for `test/data/large_dataset.csv` is not on the server, so checkout fails with a 404 that reads like repository corruption. Only `GIT_LFS_SKIP_SMUDGE=1` gets past it, and that leaves the pointer file where the content should be.

## The pointer was never produced by git-lfs

- `7ab0e35` committed it with `e3b0c442…` — the sha256 of the **empty string** — and `size 45`.
- `34bdebd` corrected the oid to `b0145878…`, still `size 45`. No object was ever pushed.
- `df0b776` then changed `size 45` to `size 30` **without touching the oid**.

An oid determines the size; those two cannot both be true. The pointer was hand-written, which is why no object exists to re-upload. Option 1 in the issue is not available.

## The content is recoverable exactly

The issue asks whether the file is genuinely 30 bytes. **It is 45.** sha256 of

```
id,name,value\n1,Test,100\n2,LFS,200\n3,Data,300
```

(45 bytes, no trailing newline) is exactly `b01458781eb3e9e62a095df408735c635e6b61a75eeb86c7662476b94bc52291`, and those are precisely the rows `test/sql/duck_tails_lfs_comprehensive.test.disabled` asserts. So the recorded oid is honest and it is the `size 30` that was wrong. That content is committed here as ordinary file content — not a regenerated stand-in.

## Nothing wants a large file here

The only reference anywhere in the tree is the disabled test above; no generator produces this path and no enabled test reads it. 45 bytes in LFS is all cost and no benefit, so this is option 3 from the issue, with the original bytes rather than a substitute.

`.gitattributes` is removed rather than trimmed. It held only this rule and a second one for `test/data/evolving_dataset.csv`, which **does not exist at any commit** — leaving it would set the same trap for whoever adds that file next.

## Deliberately not done

`duck_tails_lfs_comprehensive.test.disabled` is left disabled. Re-enabling it would turn an LFS test into a plain-file test that no longer exercises the LFS code path at all, which is worse than an honestly disabled test. Whether that path should get real coverage is a separate question.

Old commits still fail to check out with LFS enabled; that is inherent to the history and only `HEAD` can be fixed. After this, a fresh clone works with no environment variables.

## Verification

```
$ git cat-file -p HEAD:test/data/large_dataset.csv | wc -c   # 45
$ sha256sum -> b01458781eb3e9e62a095df408735c635e6b61a75eeb86c7662476b94bc52291
$ git lfs ls-files                                            # empty at HEAD
```
Full suite green on this branch alongside the other fixes.

Fresh clone, no environment variables, same source repository:

```
$ git clone --branch main --single-branch <repo> /tmp/a
error: external filter 'git-lfs filter-process' failed
fatal: test/data/large_dataset.csv: smudge filter lfs failed
warning: Clone succeeded, but checkout failed.

$ git clone --branch fix/43-lfs-fixture --single-branch <repo> /tmp/b
$ cat /tmp/b/test/data/large_dataset.csv
id,name,value
1,Test,100
2,LFS,200
3,Data,300
```
