### PR TITLE
Four silent wrong-answer bugs found triaging #26 (whose own four findings were already fixed)

### DIFF
--- a/docs/reference/git_read.md
+++ b/docs/reference/git_read.md
@@ -159,5 +159,11 @@ SELECT * FROM read_parquet('git://data/metrics.parquet@v1.0');
 - Text files have content in the `text` column
 - Binary files have content in the `blob` column
 - The `truncated` column indicates if content was cut off (for very large files)
-- Git LFS files are automatically detected and their real content is returned
+- `size_bytes` always reports the whole file, never the number of bytes returned
+- A `max_bytes` budget never changes `is_text`: the file is classified whole, and
+  a text file is cut back to a character boundary so `text` stays valid UTF-8
+- Git LFS files are automatically detected and their real content is returned,
+  read from the local LFS object store (`.git/lfs/objects/`). An object that has
+  not been pulled raises an error naming it — the same error `read_text()` gives —
+  rather than returning the pointer text as if it were the file
 - Use `git_read_each()` for efficient multi-file reads via LATERAL joins

--- a/src/git_diff_tree.cpp
+++ b/src/git_diff_tree.cpp
@@ -447,6 +447,31 @@ static OperatorResultType GitDiffTreeEachFunction(ExecutionContext &context, Tab
 				continue;
 			}
 
+			// The refs, when the caller passed them, arrive as the second and
+			// third runtime columns. A correlated (LATERAL) call is bound as a
+			// TABLE_IN_OUT function and DuckDB leaves TableFunctionBindInput::inputs
+			// empty for those, so GitDiffTreeEachBind saw no arguments at all and
+			// the bind data kept ref="HEAD", ref2="". CollectDiffRows reads an
+			// empty ref2 as "diff against the working directory", so
+			// git_diff_tree_each(r.repo, 'v1.0', 'v2.0') silently answered a
+			// different question -- HEAD vs the dirty worktree -- instead of
+			// v1.0..v2.0.
+			auto row_column_string = [&](idx_t col) {
+				string value;
+				if (input.ColumnCount() > col && !FlatVector::IsNull(input.data[col], state.current_input_row)) {
+					auto col_data = FlatVector::GetData<string_t>(input.data[col]);
+					if (col_data) {
+						value = string(col_data[state.current_input_row].GetData(),
+						               col_data[state.current_input_row].GetSize());
+					}
+				}
+				return value;
+			};
+			string row_ref = row_column_string(1);
+			string row_ref2 = row_column_string(2);
+			const string &requested_ref = row_ref.empty() ? bind_data.ref : row_ref;
+			const string &requested_ref2 = row_ref2.empty() ? bind_data.ref2 : row_ref2;
+
 			// Resolve repo path
 			string resolved_repo_path;
 			try {
@@ -467,7 +492,7 @@ static OperatorResultType GitDiffTreeEachFunction(ExecutionContext &context, Tab
 			}
 
 			try {
-				CollectDiffRows(repo, resolved_repo_path, bind_data.ref, bind_data.ref2, bind_data.path_filter,
+				CollectDiffRows(repo, resolved_repo_path, requested_ref, requested_ref2, bind_data.path_filter,
 				                bind_data.include_untracked, state.current_rows);
 			} catch (...) {
 				git_repository_free(repo);

--- a/src/git_filesystem.cpp
+++ b/src/git_filesystem.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 #include <fstream>
+#include <sstream>
 
 namespace duckdb {
 
@@ -160,9 +161,28 @@ static size_t FindGlobSuffixStart(const string &revision_spec) {
 // keep the longest prefix that actually resolves and treat the remainder as a
 // path. When nothing resolves, the ref is left exactly as written so the error
 // names the ref the user asked for instead of its first component.
+static bool IsPseudoRef(const string &revision, RefKind &out_kind);
+
 static void SplitRevisionFromPath(const string &repository_path, string &revision, string &path_suffix) {
-	if (revision.find('/') == string::npos) {
+	size_t first_slash = revision.find('/');
+	if (first_slash == string::npos) {
 		return; // no ambiguity to resolve
+	}
+
+	// WORKDIR and STAGED are duck_tails pseudo-refs, not git refs, so
+	// git_revparse_single can never resolve them and the probing below would
+	// keep the whole "STAGED/src" as the revision. The split is unambiguous
+	// here -- no git ref is named WORKDIR/... or STAGED/... -- so take it
+	// lexically. Without this, "git://repo@STAGED/src/*.csv" failed with
+	// "revspec 'STAGED/src' not found" while "git://repo@STAGED/*.csv" worked,
+	// which made only top-level globs usable over the index or the worktree.
+	{
+		RefKind pseudo_kind;
+		if (IsPseudoRef(revision.substr(0, first_slash), pseudo_kind)) {
+			path_suffix = revision.substr(first_slash) + path_suffix;
+			revision = revision.substr(0, first_slash);
+			return;
+		}
 	}
 
 	// Note: the probing below leaves libgit2's thread-local error slot set when a
@@ -551,6 +571,14 @@ unique_ptr<FileHandle> GitFileSystem::OpenFile(const string &path, FileOpenFlags
 	}
 }
 
+// Defined with the tree-globbing helpers further down. The index branch of Glob
+// has to select paths exactly the way ListFiles selects them in a commit tree:
+// the caller writes one pattern and only the ref after '@' decides which branch
+// answers it, so any difference between the two is a difference the caller
+// cannot see.
+static bool PatternHasGlob(const string &pattern);
+static bool GlobPathMatches(const vector<string> &parts, size_t pi, const vector<string> &pattern_parts, size_t qi);
+
 vector<OpenFileInfo> GitFileSystem::Glob(const string &pattern, FileOpener *opener) {
 	try {
 		auto git_path = GitPath::Parse(pattern);
@@ -579,7 +607,27 @@ vector<OpenFileInfo> GitFileSystem::Glob(const string &pattern, FileOpener *open
 					// Return empty on error
 				}
 			} else {
-				// INDEX: enumerate index entries matching pattern
+				// INDEX: select the index entries the pattern names.
+				//
+				// This used to be a StringUtil::StartsWith against the raw
+				// pattern text, which answered two different questions wrongly
+				// and silently. A pattern carrying a wildcard is never a literal
+				// prefix of a path, so `git://repo@STAGED/**/*.csv` matched
+				// nothing and the query returned zero rows with no error --
+				// while the same pattern at `@HEAD` walks the tree and works. In
+				// the other direction a pattern that IS a prefix over-matched:
+				// `git://repo/src/uti@STAGED` reported src/util.py, a path the
+				// caller never asked for and cannot have meant.
+				//
+				// Use the same matcher ListFiles applies to a commit tree, so
+				// one pattern means one thing whichever ref answers it.
+				if (git_path.file_path.empty()) {
+					// A repository URI with no path names no file, as in ListFiles.
+					return results;
+				}
+				const bool has_glob = PatternHasGlob(git_path.file_path);
+				const vector<string> pattern_parts =
+				    has_glob ? StringUtil::Split(git_path.file_path, '/') : vector<string>();
 				try {
 					git_repository *repo_ptr = nullptr;
 					int error = git_repository_open_ext(&repo_ptr, git_path.repository_path.c_str(),
@@ -596,14 +644,22 @@ vector<OpenFileInfo> GitFileSystem::Glob(const string &pattern, FileOpener *open
 							size_t entry_count = git_index_entrycount(index);
 							for (size_t i = 0; i < entry_count; i++) {
 								const git_index_entry *entry = git_index_get_byindex(index, i);
-								if (entry && entry->path) {
-									string entry_path(entry->path);
-									// Simple prefix match for now
-									if (git_path.file_path.empty() ||
-									    StringUtil::StartsWith(entry_path, git_path.file_path)) {
-										results.emplace_back(OpenFileInfo {"git://" + git_path.repository_path + "/" +
-										                                   entry_path + "@STAGED"});
-									}
+								if (!entry || !entry->path) {
+									continue;
+								}
+								// A submodule is recorded in the index as a commit
+								// entry. It is not a readable file, and ListFiles
+								// skips the same thing in a tree.
+								if (entry->mode == GIT_FILEMODE_COMMIT) {
+									continue;
+								}
+								string entry_path(entry->path);
+								bool matched =
+								    has_glob ? GlobPathMatches(StringUtil::Split(entry_path, '/'), 0, pattern_parts, 0)
+								             : entry_path == git_path.file_path;
+								if (matched) {
+									results.emplace_back(OpenFileInfo {"git://" + git_path.repository_path + "/" +
+									                                   entry_path + "@STAGED"});
 								}
 							}
 							git_index_free(index);
@@ -1480,6 +1536,32 @@ string GitLFSFileHandle::BuildLFSObjectPath(const string &oid) {
 	return ConfineUnderDirectory(objects_root, lfs_path, "LFS object path");
 }
 
+// The single place that says "this LFS object is not here". Both readers -- the
+// git:// file handle and git_read() -- have to fail in the same words, or one
+// missing object reads as two unrelated problems.
+void ThrowLFSObjectNotInLocalCache(const string &path, const LFSInfo &lfs_info, const string &local_path) {
+	throw IOException("Git LFS object for '%s' is not in the local LFS cache, and fetching it from the LFS "
+	                  "server is not implemented yet. Run 'git lfs pull' in the repository to download it. "
+	                  "(object sha256:%s, %s bytes, expected at %s)",
+	                  path, lfs_info.oid, std::to_string(lfs_info.size), local_path);
+}
+
+bool SubstituteLFSPointerContent(git_repository *repo, const string &path, string &content) {
+	if (!GitFileSystem::IsLFSPointer(content)) {
+		return false;
+	}
+	auto lfs_info = GitFileSystem::ParseLFSPointer(content);
+	string local_path = GitFileSystem::BuildLFSObjectPath(repo, lfs_info.oid);
+	std::ifstream object_file(local_path, std::ios::binary);
+	if (!object_file.good()) {
+		ThrowLFSObjectNotInLocalCache(path, lfs_info, local_path);
+	}
+	std::ostringstream buffer;
+	buffer << object_file.rdbuf();
+	content = buffer.str();
+	return true;
+}
+
 string GitLFSFileHandle::ResolveLFSDownloadURL() {
 	// TODO: Implement the LFS Batch API so objects can be fetched on demand.
 	//
@@ -1488,10 +1570,8 @@ string GitLFSFileHandle::ResolveLFSDownloadURL() {
 	// empty file) would feed a query data that looks real and is not. The
 	// message says which object is missing and how to get it.
 	string local_path = BuildLFSObjectPath(lfs_info_.oid);
-	throw IOException("Git LFS object for '%s' is not in the local LFS cache, and fetching it from the LFS "
-	                  "server is not implemented yet. Run 'git lfs pull' in the repository to download it. "
-	                  "(object sha256:%s, %s bytes, expected at %s)",
-	                  path, lfs_info_.oid, std::to_string(lfs_info_.size), local_path);
+	ThrowLFSObjectNotInLocalCache(path, lfs_info_, local_path);
+	return string(); // unreachable
 }
 
 LFSConfig GitLFSFileHandle::ReadLFSConfig() {

--- a/src/git_log.cpp
+++ b/src/git_log.cpp
@@ -332,6 +332,22 @@ static OperatorResultType GitLogEachFunction(ExecutionContext &context, TableFun
 				throw BinderException("git_log_each: received empty repo_path_or_uri from input");
 			}
 
+			// The ref, when the caller passed one, arrives as the second runtime
+			// column. A correlated (LATERAL) call is bound as a TABLE_IN_OUT
+			// function, and DuckDB leaves TableFunctionBindInput::inputs empty for
+			// those -- every argument comes through the DataChunk instead. Reading
+			// the ref only at bind time meant git_log_each(r.repo, r.ref) walked
+			// HEAD for every driver row while the all-literal call honoured it.
+			string row_ref;
+			if (input.ColumnCount() > 1 && !FlatVector::IsNull(input.data[1], state.current_input_row)) {
+				auto ref_data = FlatVector::GetData<string_t>(input.data[1]);
+				if (ref_data) {
+					row_ref = string(ref_data[state.current_input_row].GetData(),
+					                 ref_data[state.current_input_row].GetSize());
+				}
+			}
+			const string &requested_ref = row_ref.empty() ? bind_data.ref : row_ref;
+
 			// Apply unified parameter processing at runtime
 			// Use GitContextManager for unified git URI processing and reference validation
 			string resolved_file_path, final_ref;
@@ -340,7 +356,7 @@ static OperatorResultType GitLogEachFunction(ExecutionContext &context, TableFun
 				// GitContextManager handles both git:// URIs and filesystem paths
 				// It also validates references and throws consistent "unable to parse OID" errors
 				// Use bind_data.ref as fallback (defaults to "HEAD" from ParseLateralGitParams)
-				auto ctx = GitContextManager::Instance().ProcessGitUri(repo_path_or_uri, bind_data.ref);
+				auto ctx = GitContextManager::Instance().ProcessGitUri(repo_path_or_uri, requested_ref);
 				resolved_repo_path = ctx.repo_path;
 				resolved_file_path = ctx.file_path;
 				final_ref = ctx.final_ref;

--- a/src/git_read.cpp
+++ b/src/git_read.cpp
@@ -152,15 +152,62 @@ static unique_ptr<GlobalTableFunctionState> GitReadInitGlobal(ClientContext &con
 	return make_uniq<GitReadGlobalState>();
 }
 
+// An LFS-tracked blob holds a ~130-byte pointer, not the file. read_text() on a
+// git:// URI already resolves that pointer through GitLFSFileHandle; git_read()
+// did not look for it at all, so the same file read two different ways gave two
+// different contents -- the object through one, the pointer text through the
+// other, with is_text=true and size_bytes=127 making the pointer look like a
+// perfectly ordinary small text file. Substitute here so both readers answer
+// the same question, and let a never-pulled object raise the same error
+// read_text() raises rather than answering with the pointer.
+//
+// Only blobs small enough to BE a pointer are copied for the check.
+static bool ResolveLFSContentIfPointer(git_repository *repo, const string &file_path, const char *&content_ptr,
+                                       size_t &content_len, string &holder) {
+	static constexpr size_t MAX_LFS_POINTER_BYTES = 1024;
+	if (content_len == 0 || content_len > MAX_LFS_POINTER_BYTES) {
+		return false;
+	}
+	holder.assign(content_ptr, content_len);
+	if (!SubstituteLFSPointerContent(repo, file_path, holder)) {
+		return false;
+	}
+	content_ptr = holder.data();
+	content_len = holder.size();
+	return true;
+}
+
 // Helper to populate text/blob content fields from raw data
 static void PopulateContentFields(const char *raw_content, size_t raw_size, int64_t max_bytes,
                                   GitReadLocalState::ReadResult &result) {
 	result.size_bytes = static_cast<int64_t>(raw_size);
 
+	// A NUL byte (0x00) is valid UTF-8 (U+0000) and a DuckDB VARCHAR is
+	// length-prefixed, so it can hold embedded NULs. We therefore classify on
+	// UTF-8 validity alone; an embedded NUL no longer forces a text blob to be
+	// reported as binary (which previously caused git_tree to say is_text=true
+	// while git_read returned NULL text for the same blob).
+	//
+	// Classify the WHOLE blob, before applying max_bytes. Cutting first made the
+	// answer depend on where the byte budget happened to land: for a file holding
+	// "café\n" (63 61 66 C3 A9 0A), git_read(..., 4) split the two-byte 'é', the
+	// prefix was not valid UTF-8, and a plain text file came back as
+	// is_text=false, encoding='binary', text=NULL. is_text describes the file, so
+	// it must not change with the byte budget.
+	const bool is_valid_utf8 = raw_size == 0 || IsValidUTF8(raw_content, raw_size);
+
 	size_t content_size = raw_size;
 	if (max_bytes > 0 && content_size > static_cast<size_t>(max_bytes)) {
 		content_size = static_cast<size_t>(max_bytes);
 		result.truncated = true;
+		if (is_valid_utf8) {
+			// Never cut inside a multi-byte sequence: back up to the start of the
+			// character the budget landed in so the text column stays valid UTF-8.
+			// A continuation byte is 10xxxxxx.
+			while (content_size > 0 && (static_cast<unsigned char>(raw_content[content_size]) & 0xC0) == 0x80) {
+				content_size--;
+			}
+		}
 	}
 
 	if (content_size == 0) {
@@ -171,13 +218,6 @@ static void PopulateContentFields(const char *raw_content, size_t raw_size, int6
 		result.text = string();
 		return;
 	}
-
-	// A NUL byte (0x00) is valid UTF-8 (U+0000) and a DuckDB VARCHAR is
-	// length-prefixed, so it can hold embedded NULs. We therefore classify on
-	// UTF-8 validity alone; an embedded NUL no longer forces a text blob to be
-	// reported as binary (which previously caused git_tree to say is_text=true
-	// while git_read returned NULL text for the same blob).
-	bool is_valid_utf8 = IsValidUTF8(raw_content, content_size);
 
 	if (is_valid_utf8) {
 		result.is_text = true;
@@ -273,21 +313,27 @@ static void ProcessIndexRead(const string &repo_path, const string &file_path, c
 	result.kind = "file";
 	result.mode = entry->mode;
 
-	// Use git_blob_is_binary for initial check, then do full validation
-	bool git_says_binary = git_blob_is_binary(blob);
+	const char *content_ptr = static_cast<const char *>(raw_content);
+	size_t content_len = static_cast<size_t>(raw_size);
+	string lfs_holder;
+	bool from_lfs = ResolveLFSContentIfPointer(repo, file_path, content_ptr, content_len, lfs_holder);
+
+	// Use git_blob_is_binary for initial check, then do full validation.
+	// An LFS object is classified on its own bytes: git_blob_is_binary would be
+	// describing the pointer, which is always text.
+	bool git_says_binary = !from_lfs && git_blob_is_binary(blob);
 	if (!git_says_binary) {
-		PopulateContentFields(static_cast<const char *>(raw_content), static_cast<size_t>(raw_size),
-		                      bind_data.max_bytes, result);
+		PopulateContentFields(content_ptr, content_len, bind_data.max_bytes, result);
 	} else {
 		result.is_text = false;
 		result.encoding = "binary";
-		result.size_bytes = static_cast<int64_t>(raw_size);
-		size_t content_size = static_cast<size_t>(raw_size);
+		result.size_bytes = static_cast<int64_t>(content_len);
+		size_t content_size = content_len;
 		if (bind_data.max_bytes > 0 && content_size > static_cast<size_t>(bind_data.max_bytes)) {
 			content_size = static_cast<size_t>(bind_data.max_bytes);
 			result.truncated = true;
 		}
-		result.blob = string(static_cast<const char *>(raw_content), content_size);
+		result.blob = string(content_ptr, content_size);
 	}
 
 	git_blob_free(blob);
@@ -442,19 +488,25 @@ static void ProcessGitURI(const string &uri, const GitReadBindData &bind_data, G
 		// helper: it builds a length-prefixed string, so embedded NUL bytes survive
 		// and an empty blob reads back as '' instead of NULL. (DuckDB VARCHAR is
 		// length-prefixed and U+0000 is valid UTF-8, so embedded NULs are valid.)
-		if (!git_blob_is_binary(blob)) {
-			PopulateContentFields(static_cast<const char *>(raw_content), static_cast<size_t>(raw_size),
-			                      bind_data.max_bytes, result);
+		const char *content_ptr = static_cast<const char *>(raw_content);
+		size_t content_len = static_cast<size_t>(raw_size);
+		string lfs_holder;
+		bool from_lfs = ResolveLFSContentIfPointer(repo, result.file_path, content_ptr, content_len, lfs_holder);
+
+		// An LFS object is classified on its own bytes: git_blob_is_binary would
+		// be describing the pointer, which is always text.
+		if (from_lfs || !git_blob_is_binary(blob)) {
+			PopulateContentFields(content_ptr, content_len, bind_data.max_bytes, result);
 		} else {
 			result.is_text = false;
 			result.encoding = "binary";
-			result.size_bytes = static_cast<int64_t>(raw_size);
-			size_t content_size = static_cast<size_t>(raw_size);
+			result.size_bytes = static_cast<int64_t>(content_len);
+			size_t content_size = content_len;
 			if (bind_data.max_bytes > 0 && content_size > static_cast<size_t>(bind_data.max_bytes)) {
 				content_size = static_cast<size_t>(bind_data.max_bytes);
 				result.truncated = true;
 			}
-			result.blob = string(static_cast<const char *>(raw_content), content_size);
+			result.blob = string(content_ptr, content_size);
 		}
 
 		// Clean up local objects

--- a/src/git_tree.cpp
+++ b/src/git_tree.cpp
@@ -736,18 +736,41 @@ static OperatorResultType GitTreeEachFunction(ExecutionContext &context, TableFu
 				continue;
 			}
 
+			// The ref, when the caller passed one, arrives as the second runtime
+			// column -- not in bind_data.
+			//
+			// DuckDB binds a table function two different ways: with all-literal
+			// arguments it is a STANDARD_TABLE_FUNCTION and TableFunctionBindInput
+			// carries the arguments, but a correlated (LATERAL) call is bound as a
+			// TABLE_IN_OUT_FUNCTION and `inputs` is left empty -- every argument
+			// arrives in the DataChunk instead. Reading the ref only at bind time
+			// therefore worked for git_tree_each('.', 'v1.0') and silently ignored
+			// it for the documented LATERAL form, which then listed HEAD's tree for
+			// every driver row. git_blame_each already reads its ref this way.
+			string row_ref;
+			if (input.ColumnCount() > 1 && !FlatVector::IsNull(input.data[1], state.current_input_row)) {
+				auto ref_data = FlatVector::GetData<string_t>(input.data[1]);
+				if (ref_data) {
+					row_ref = string(ref_data[state.current_input_row].GetData(),
+					                 ref_data[state.current_input_row].GetSize());
+				}
+			}
+			const string &requested_ref = row_ref.empty() ? bind_data.ref : row_ref;
+
 			// Apply unified parameter processing at runtime
 			// Use GitContextManager for unified git URI processing and reference validation
 			string resolved_file_path, final_ref;
+			RefKind row_ref_kind = RefKind::COMMIT;
 
 			try {
 				// GitContextManager handles both git:// URIs and filesystem paths
 				// It also validates references and throws consistent "unable to parse OID" errors
 				// Use bind_data.ref as fallback (defaults to "HEAD" from ParseLateralGitParams)
-				auto ctx = GitContextManager::Instance().ProcessGitUri(repo_path_or_uri, bind_data.ref);
+				auto ctx = GitContextManager::Instance().ProcessGitUri(repo_path_or_uri, requested_ref);
 				resolved_repo_path = ctx.repo_path;
 				resolved_file_path = ctx.file_path;
 				final_ref = ctx.final_ref;
+				row_ref_kind = ctx.ref_kind;
 
 				// Note: ctx.repo and ctx.resolved_object are managed by GitContextManager
 				// No need to free them here - GitContextManager handles caching and cleanup
@@ -772,7 +795,24 @@ static OperatorResultType GitTreeEachFunction(ExecutionContext &context, TableFu
 			}
 
 			try {
-				ProcessSingleCommit(repo, final_ref, resolved_repo_path, resolved_file_path, state.current_rows);
+				// Dispatch on the pseudo-ref exactly as GitTreeInitGlobal does.
+				// This branch used to call ProcessSingleCommit unconditionally,
+				// and WORKDIR/STAGED are not revspecs: git_revparse_single failed,
+				// the catch below swallowed it, and git_tree_each('git://.@WORKDIR')
+				// returned zero rows with no error while git_tree() on the same
+				// URI returned the full listing.
+				switch (row_ref_kind) {
+				case RefKind::WORKDIR:
+					ProcessWorkdirTree(repo, resolved_repo_path, resolved_file_path, bind_data.include_untracked,
+					                   state.current_rows);
+					break;
+				case RefKind::INDEX:
+					ProcessIndexTree(repo, resolved_repo_path, resolved_file_path, state.current_rows);
+					break;
+				case RefKind::COMMIT:
+					ProcessSingleCommit(repo, final_ref, resolved_repo_path, resolved_file_path, state.current_rows);
+					break;
+				}
 			} catch (...) {
 				git_repository_free(repo);
 				// Skip failed processing in LATERAL context - just move to next input

--- a/src/include/git_filesystem.hpp
+++ b/src/include/git_filesystem.hpp
@@ -192,6 +192,15 @@ public:
 	idx_t SeekPosition(FileHandle &handle) override;
 	void Reset(FileHandle &handle) override;
 
+	// LFS pointer recognition and resolution. Public and static because the
+	// table functions have to reach the same answer this filesystem reaches:
+	// git_read() used to hand back the 130-byte pointer text as a file's
+	// content while read_text() on the same URI returned the object, and
+	// neither raised anything.
+	static bool IsLFSPointer(const string &content);
+	static LFSInfo ParseLFSPointer(const string &pointer_content);
+	static string BuildLFSObjectPath(git_repository *repo, const string &oid);
+
 private:
 	// Git repository management
 	git_repository *OpenRepository(const string &repo_path);
@@ -200,15 +209,19 @@ private:
 	vector<OpenFileInfo> ListFiles(git_repository *repo, const GitPath &git_path, git_object *commit_obj);
 
 	// LFS support methods
-	bool IsLFSPointer(const string &content);
-	LFSInfo ParseLFSPointer(const string &pointer_content);
 	LFSConfig ReadLFSConfig(git_repository *repo);
-	string BuildLFSObjectPath(git_repository *repo, const string &oid);
 	LFSBatchResponse CallLFSBatchAPI(const LFSConfig &config, const LFSInfo &lfs_info);
 
 	// Cache for opened repositories
 	std::unordered_map<string, git_repository *> repo_cache_;
 };
+
+// Replaces `content` with the bytes the git-lfs pointer it holds stands for,
+// read from the local LFS object store (.git/lfs/objects). Returns false and
+// leaves `content` untouched when it is not a pointer. Throws when it IS a
+// pointer whose object was never pulled: there is no LFS Batch API client here,
+// and answering with the pointer text would feed a query data that looks real.
+bool SubstituteLFSPointerContent(git_repository *repo, const string &path, string &content);
 
 void RegisterGitFileSystem(ExtensionLoader &loader);
 

--- a/test/fixtures/setup_fixtures.sh
+++ b/test/fixtures/setup_fixtures.sh
@@ -81,6 +81,19 @@ setup_fixtures() {
     echo "Generating slash-bearing ref fixture..."
     bash "$FIXTURES_DIR/../scripts/setup_slash_refs_fixture.sh" "$TEMP_DIR"
 
+    # The index-side counterpart of the slash-refs fixture: a repository whose
+    # index holds more (and different) paths than HEAD, at more than one depth,
+    # so the @STAGED branch of Glob can be tested without an assertion passing
+    # by accidentally reading the commit tree.
+    echo "Generating staged-glob fixture..."
+    bash "$FIXTURES_DIR/../scripts/setup_staged_glob_fixture.sh" "$TEMP_DIR"
+
+    # An LFS-tracked pair: one object present in the local store, one absent.
+    # duck_tails has no LFS Batch API client, so the absent one has to fail
+    # loudly rather than hand back the pointer text as file content (#26).
+    echo "Generating LFS local-cache fixture..."
+    bash "$FIXTURES_DIR/../scripts/setup_lfs_missing_object_fixture.sh" "$TEMP_DIR"
+
     # A second spelling of main-repo whose textual form differs from the one
     # libgit2 resolves it to. GitPath::Parse derived the in-repository path by
     # stripping libgit2's repository root off the input as text, so an input that

--- a/test/scripts/setup_lfs_missing_object_fixture.sh
+++ b/test/scripts/setup_lfs_missing_object_fixture.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Generates the LFS local-cache fixture used by test/sql/git_lfs_local_cache.test.
+#
+# duck_tails serves an LFS-tracked file from the local object store
+# (.git/lfs/objects/ab/cd/<oid>) and has no LFS Batch API client, so an object
+# that was never pulled cannot be produced. The two cases have to be told
+# apart, and neither may ever hand the caller the pointer text as if it were
+# the file's content:
+#
+#   present.dat  - pointer whose 64-hex object IS materialized locally; reading
+#                  it must return the object's content, not the pointer.
+#   missing.dat  - pointer whose object is NOT in the local store; reading it
+#                  must raise an error that names the object and says how to
+#                  get it, rather than returning pointer text or an empty file.
+#
+# Generated rather than committed so no part of it depends on git-lfs being
+# installed, on a remote being reachable, or on this repository's own
+# .gitattributes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEMP_DIR="${1:-$PROJECT_ROOT/test/tmp}"
+mkdir -p "$TEMP_DIR"
+
+REPO="$TEMP_DIR/lfs-cache-repo"
+
+rm -rf "$REPO"
+mkdir -p "$REPO"
+cd "$REPO"
+
+git init -q
+git checkout -q -b main
+git config user.email "test@example.com"
+git config user.name "Test User"
+git config commit.gpgsign false
+# Do not let a host git-lfs smudge/clean filter rewrite these pointers.
+git config filter.lfs.smudge "cat"
+git config filter.lfs.clean "cat"
+
+GIT_DIR_ABS="$(cd "$REPO/.git" && pwd)"
+
+write_pointer() {
+    # $1 = filename, $2 = oid, $3 = size
+    cat > "$1" <<EOF
+version https://git-lfs.github.com/spec/v1
+oid sha256:$2
+size $3
+EOF
+}
+
+# --- present.dat: object materialized in the local store -------------
+PRESENT_CONTENT="lfs object served from the local cache"
+PRESENT_SIZE=$(printf '%s' "$PRESENT_CONTENT" | wc -c | tr -d ' ')
+PRESENT_OID=$(printf '%s' "$PRESENT_CONTENT" | sha256sum | awk '{print $1}')
+write_pointer "present.dat" "$PRESENT_OID" "$PRESENT_SIZE"
+OBJ_DIR="$GIT_DIR_ABS/lfs/objects/${PRESENT_OID:0:2}/${PRESENT_OID:2:2}"
+mkdir -p "$OBJ_DIR"
+printf '%s' "$PRESENT_CONTENT" > "$OBJ_DIR/$PRESENT_OID"
+
+# --- missing.dat: well-formed oid, nothing in the local store --------
+MISSING_CONTENT="this object is deliberately never materialized"
+MISSING_SIZE=$(printf '%s' "$MISSING_CONTENT" | wc -c | tr -d ' ')
+MISSING_OID=$(printf '%s' "$MISSING_CONTENT" | sha256sum | awk '{print $1}')
+write_pointer "missing.dat" "$MISSING_OID" "$MISSING_SIZE"
+
+git add present.dat missing.dat
+git commit -q -m "LFS local-cache fixture"
+
+echo "LFS local-cache fixture ready at: $REPO"
+echo "  present.dat oid=$PRESENT_OID (object materialized locally)"
+echo "  missing.dat oid=$MISSING_OID (object absent)"

--- a/test/scripts/setup_staged_glob_fixture.sh
+++ b/test/scripts/setup_staged_glob_fixture.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Generates the staged-glob fixture used by test/sql/git_staged_glob.test.
+#
+# The @STAGED / @INDEX branch of GitFileSystem::Glob enumerates the git index.
+# It needs a repository whose index holds strictly more (and different) files
+# than HEAD, so an assertion cannot pass by accidentally reading the commit
+# tree, and whose staged paths live at more than one depth, so per-component
+# glob matching ('**' crawls, '*' does not cross '/') is actually exercised.
+#
+# Generated rather than committed as a tarball because a *staged* state is the
+# point: tar preserves the index file, but a checked-in fixture whose whole
+# value is "these paths are in the index and not in HEAD" is far easier to read
+# as a script than as a binary blob.
+#
+# Layout:
+#   HEAD   -> README.md ("committed"), src/main.py, utf8.txt        (3 entries)
+#   index  -> README.md (modified, staged), app.js, data/rows.csv,
+#             notes.txt, src/main.py, src/util.py, utf8.txt        (7 entries)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEMP_DIR="${1:-$PROJECT_ROOT/test/tmp}"
+mkdir -p "$TEMP_DIR"
+
+REPO="$TEMP_DIR/staged-glob-repo"
+
+rm -rf "$REPO"
+mkdir -p "$REPO"
+cd "$REPO"
+
+git init -q
+# Name the initial branch explicitly: the default differs across git versions
+# and host configuration.
+git checkout -q -b main
+git config user.email "test@example.com"
+git config user.name "Test User"
+git config commit.gpgsign false
+
+mkdir -p src data
+
+# --- the commit: three files -----------------------------------------
+printf 'committed\n' > README.md
+printf 'print("main")\n' > src/main.py
+# A file with a multi-byte UTF-8 character, for git_read's max_bytes boundary:
+# 'caf\xc3\xa9\n' is 6 bytes, so a 4-byte budget lands inside the two-byte 'e-acute'.
+printf 'caf\xc3\xa9\n' > utf8.txt
+git add README.md src/main.py utf8.txt
+git commit -q -m "initial commit"
+
+# --- the index: seven files, four of them never committed ------------
+printf 'staged\n' > README.md
+printf 'console.log("app");\n' > app.js
+printf 'id,name\n1,alpha\n2,beta\n' > data/rows.csv
+printf 'staged notes\n' > notes.txt
+printf 'print("util")\n' > src/util.py
+git add README.md app.js data/rows.csv notes.txt src/util.py
+
+echo "Staged-glob fixture ready at: $REPO"
+git --no-pager ls-files --cached | sed 's/^/  index /'

--- a/test/sql/git_each_lateral_ref.test
+++ b/test/sql/git_each_lateral_ref.test
@@ -1,0 +1,136 @@
+# name: test/sql/git_each_lateral_ref.test
+# description: The _each table functions must honour a ref supplied by a correlated (LATERAL) argument
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# Fixture: test/tmp/slash-refs-repo
+#   main         1 commit,  README.md, data/, data/rows.csv          (3 tree rows)
+#   feature/foo  2 commits, + feature-only.txt                       (4 tree rows)
+#
+# DuckDB binds a table function two different ways. With all-literal arguments
+# it is a STANDARD_TABLE_FUNCTION and TableFunctionBindInput carries them; a
+# correlated call is bound as a TABLE_IN_OUT_FUNCTION and `inputs` is left
+# empty, so every argument arrives in the runtime DataChunk instead. Reading
+# the ref only at bind time therefore worked for the literal call and silently
+# ignored it for the LATERAL form -- which is the form the docs lead with.
+# Every assertion below is written as literal-vs-LATERAL so a regression cannot
+# hide behind a fixture whose refs happen to agree.
+
+# --- git_tree_each ---------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM git_tree_each('test/tmp/slash-refs-repo', 'main');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_tree_each('test/tmp/slash-refs-repo', 'feature/foo');
+----
+4
+
+query II
+SELECT r.ref, COUNT(*)
+FROM (VALUES ('main'), ('feature/foo')) AS r(ref),
+     LATERAL git_tree_each('test/tmp/slash-refs-repo', r.ref) t
+GROUP BY r.ref ORDER BY r.ref;
+----
+feature/foo	4
+main	3
+
+# The branch-only file is only ever reported for the branch that carries it.
+query I
+SELECT COUNT(*)
+FROM (VALUES ('main')) AS r(ref),
+     LATERAL git_tree_each('test/tmp/slash-refs-repo', r.ref) t
+WHERE t.file_path = 'feature-only.txt';
+----
+0
+
+query I
+SELECT COUNT(*)
+FROM (VALUES ('feature/foo')) AS r(ref),
+     LATERAL git_tree_each('test/tmp/slash-refs-repo', r.ref) t
+WHERE t.file_path = 'feature-only.txt';
+----
+1
+
+# --- git_log_each ----------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM git_log_each('test/tmp/slash-refs-repo', 'main');
+----
+1
+
+query I
+SELECT COUNT(*) FROM git_log_each('test/tmp/slash-refs-repo', 'feature/foo');
+----
+2
+
+query II
+SELECT r.ref, COUNT(*)
+FROM (VALUES ('main'), ('feature/foo')) AS r(ref),
+     LATERAL git_log_each('test/tmp/slash-refs-repo', r.ref) l
+GROUP BY r.ref ORDER BY r.ref;
+----
+feature/foo	2
+main	1
+
+# --- git_diff_tree_each ----------------------------------------------
+#
+# With no second ref, CollectDiffRows diffs against the working directory --
+# a different question entirely. A LATERAL call that supplied both refs used to
+# fall into that branch, because the bind data kept ref='HEAD' and ref2=''.
+# main..feature/foo changes README.md and data/rows.csv and adds
+# feature-only.txt.
+
+query I
+SELECT COUNT(*) FROM git_diff_tree_each('test/tmp/slash-refs-repo', 'main', 'feature/foo');
+----
+3
+
+query I
+SELECT COUNT(*)
+FROM (VALUES ('test/tmp/slash-refs-repo')) AS r(repo),
+     LATERAL git_diff_tree_each(r.repo, 'main', 'feature/foo') d;
+----
+3
+
+query I
+SELECT COUNT(*)
+FROM (VALUES ('main', 'feature/foo')) AS r(a, b),
+     LATERAL git_diff_tree_each('test/tmp/slash-refs-repo', r.a, r.b) d
+WHERE d.file_path = 'feature-only.txt';
+----
+1
+
+# --- pseudo-refs through _each ---------------------------------------
+#
+# git_tree_each called ProcessSingleCommit unconditionally and swallowed the
+# failure, so a WORKDIR/STAGED URI returned zero rows with no error while
+# git_tree() on the very same URI returned the full listing.
+
+query I
+SELECT COUNT(*) FROM git_tree('git://test/tmp/staged-glob-repo@WORKDIR') WHERE kind = 'file';
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_tree_each('git://test/tmp/staged-glob-repo@WORKDIR') WHERE kind = 'file';
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_tree('git://test/tmp/staged-glob-repo@STAGED');
+----
+7
+
+query I
+SELECT COUNT(*) FROM git_tree_each('git://test/tmp/staged-glob-repo@STAGED');
+----
+7

--- a/test/sql/git_lfs_local_cache.test
+++ b/test/sql/git_lfs_local_cache.test
@@ -75,7 +75,19 @@ SELECT text FROM git_read('git://test/tmp/lfs_oid_traversal_repo/leak.dat@HEAD')
 ----
 expected exactly 64 lowercase hex characters
 
-query I
-SELECT text NOT LIKE '%SECRET-CANARY%' FROM read_text('git://test/tmp/lfs_oid_traversal_repo/valid.dat@HEAD') t(text);
+# ...while the pointer next to it, whose oid is well-formed, still resolves to
+# its own object. read_text's first column is `filename`, not `content`, so a
+# one-name table alias here would have renamed the URI and asserted that the
+# URI does not contain the canary -- true no matter what the file holds. Name
+# the column instead, and pin the content rather than only its absence, so the
+# assertion fails if the read stops working at all.
+query II
+SELECT content, content NOT LIKE '%SECRET-CANARY%'
+FROM read_text('git://test/tmp/lfs_oid_traversal_repo/valid.dat@HEAD');
 ----
-true
+valid-lfs-object-content	true
+
+query I
+SELECT text FROM git_read('git://test/tmp/lfs_oid_traversal_repo/valid.dat@HEAD');
+----
+valid-lfs-object-content

--- a/test/sql/git_lfs_local_cache.test
+++ b/test/sql/git_lfs_local_cache.test
@@ -1,0 +1,81 @@
+# name: test/sql/git_lfs_local_cache.test
+# description: Reading Git LFS files from the local object store, and failing loudly when the object was never pulled
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# Fixture: test/tmp/lfs-cache-repo
+#   present.dat  pointer whose object IS in .git/lfs/objects
+#   missing.dat  pointer whose object is NOT
+
+# An LFS-tracked file whose object is in the local store reads as the object,
+# not as the pointer text.
+query I
+SELECT content FROM read_text('git://test/tmp/lfs-cache-repo/present.dat@HEAD');
+----
+lfs object served from the local cache
+
+query I
+SELECT content NOT LIKE '%git-lfs.github.com%' FROM read_text('git://test/tmp/lfs-cache-repo/present.dat@HEAD');
+----
+true
+
+# An object that was never pulled cannot be produced: there is no LFS Batch API
+# client here. Returning the pointer text (or an empty file) would feed a query
+# data that looks real, so this is an error -- and the error has to say which
+# object is missing and how to get it.
+statement error
+SELECT content FROM read_text('git://test/tmp/lfs-cache-repo/missing.dat@HEAD');
+----
+git lfs pull
+
+statement error
+SELECT content FROM read_text('git://test/tmp/lfs-cache-repo/missing.dat@HEAD');
+----
+not in the local LFS cache
+
+# git_read reports the same thing rather than surfacing the pointer as content.
+statement error
+SELECT text FROM git_read('git://test/tmp/lfs-cache-repo/missing.dat@HEAD');
+----
+git lfs pull
+
+# git_read and read_text must agree about the file's content and its size. The
+# pointer is 127 bytes; the object it names is 38. git_read used to report the
+# pointer -- is_text=true, size_bytes=127 -- which is a perfectly plausible
+# small text file and in no way the file the caller asked for.
+query III
+SELECT is_text, size_bytes, text FROM git_read('git://test/tmp/lfs-cache-repo/present.dat@HEAD');
+----
+true	38	lfs object served from the local cache
+
+query I
+SELECT COUNT(*) FROM git_read('git://test/tmp/lfs-cache-repo/present.dat@HEAD') r,
+                    read_text('git://test/tmp/lfs-cache-repo/present.dat@HEAD') t
+WHERE r.text = t.content;
+----
+1
+
+# The staging area reads the same way.
+query II
+SELECT is_text, size_bytes FROM git_read('git://test/tmp/lfs-cache-repo/present.dat@STAGED');
+----
+true	38
+
+# Now that git_read resolves pointers, it is on the same path as the filesystem
+# reader and must reject the same malformed OIDs. A pointer whose oid is a
+# traversal string never reaches the object store.
+statement error
+SELECT text FROM git_read('git://test/tmp/lfs_oid_traversal_repo/leak.dat@HEAD');
+----
+expected exactly 64 lowercase hex characters
+
+query I
+SELECT text NOT LIKE '%SECRET-CANARY%' FROM read_text('git://test/tmp/lfs_oid_traversal_repo/valid.dat@HEAD') t(text);
+----
+true

--- a/test/sql/git_read_max_bytes_utf8.test
+++ b/test/sql/git_read_max_bytes_utf8.test
@@ -1,0 +1,59 @@
+# name: test/sql/git_read_max_bytes_utf8.test
+# description: git_read's max_bytes budget must not change what the file is
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# Fixture: test/tmp/staged-glob-repo/utf8.txt holds 'caf\xc3\xa9\n' -- six bytes,
+# with a two-byte character spanning offsets 3 and 4.
+
+query IIII
+SELECT is_text, encoding, truncated, size_bytes
+FROM git_read('git://test/tmp/staged-glob-repo/utf8.txt@HEAD');
+----
+true	utf8	false	6
+
+# A budget landing inside the multi-byte character used to split it. The prefix
+# was then not valid UTF-8, so a plain text file was reported as
+# is_text=false, encoding='binary', text=NULL -- the byte budget silently
+# changed the answer to "what kind of file is this?".
+query IIII
+SELECT is_text, encoding, truncated, size_bytes
+FROM git_read('git://test/tmp/staged-glob-repo/utf8.txt@HEAD', 4);
+----
+true	utf8	true	6
+
+# The text is cut back to a character boundary rather than mid-sequence.
+query I
+SELECT text FROM git_read('git://test/tmp/staged-glob-repo/utf8.txt@HEAD', 4);
+----
+caf
+
+query I
+SELECT text FROM git_read('git://test/tmp/staged-glob-repo/utf8.txt@HEAD', 5);
+----
+café
+
+# size_bytes always reports the blob, never the budget.
+query II
+SELECT truncated, size_bytes FROM git_read('git://test/tmp/staged-glob-repo/utf8.txt@HEAD', 100);
+----
+false	6
+
+# A budget that cannot hold even the first character yields empty text, not a
+# broken one.
+query II
+SELECT truncated, text FROM git_read('git://test/tmp/staged-glob-repo/utf8.txt@HEAD', 1);
+----
+true	c
+
+# An ASCII file is unaffected by any of this.
+query III
+SELECT is_text, truncated, text FROM git_read('git://test/tmp/staged-glob-repo/src/main.py@HEAD', 5);
+----
+true	true	print

--- a/test/sql/git_staged_glob.test
+++ b/test/sql/git_staged_glob.test
@@ -1,0 +1,141 @@
+# name: test/sql/git_staged_glob.test
+# description: Globbing the git index through the git:// filesystem (@STAGED / @INDEX)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# Fixture: test/tmp/staged-glob-repo
+#   HEAD  -> README.md, src/main.py, utf8.txt                        (3 entries)
+#   index -> README.md, app.js, data/rows.csv, notes.txt,
+#            src/main.py, src/util.py, utf8.txt                      (7 entries)
+
+# '**' crawls the whole index. The index branch used to compare the pattern to
+# each entry path with StringUtil::StartsWith, so a pattern that is not a
+# literal path prefix matched nothing and the query returned zero rows with no
+# error at all.
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/**');
+----
+7
+
+# ...and the index really is a different set of files from HEAD
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@HEAD/**');
+----
+3
+
+# @INDEX is the same pseudo-ref under its other spelling
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@INDEX/**');
+----
+7
+
+# Filtering on the trailing component
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/**/*.py');
+----
+2
+
+# A glob written in the path part of the URI resolves the same way
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo/**/*.py@STAGED');
+----
+2
+
+# Wildcards do not cross directory separators
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/*.js');
+----
+1
+
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/*.py');
+----
+0
+
+# Directory-scoped glob
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/src/*.py');
+----
+2
+
+# '?' matches a single character
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/app.?s');
+----
+1
+
+# Character classes
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/src/[mu]*.py');
+----
+2
+
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED/src/[!m]*.py');
+----
+1
+
+# An exact path names exactly that file...
+query I
+SELECT file LIKE '%/staged-glob-repo/src/util.py@STAGED' FROM glob('git://test/tmp/staged-glob-repo/src/util.py@STAGED');
+----
+true
+
+# ...and a truncation of it names nothing. Prefix matching used to answer this
+# with src/util.py, and a caller that read the result back got content for a
+# path it never asked for.
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo/src/uti@STAGED');
+----
+0
+
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo/src@STAGED');
+----
+0
+
+# A repository URI with no path names no file, exactly as the commit-tree
+# branch answers it. It used to hand back every entry in the index, so
+# read_csv('git://repo@STAGED') fed every staged file to the CSV parser.
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@STAGED');
+----
+0
+
+# The URIs handed back are re-openable and carry the pseudo-ref, so the read
+# comes from the index and not from the working directory or HEAD.
+query I
+SELECT COUNT(*) FROM read_csv('git://test/tmp/staged-glob-repo/data/*.csv@STAGED');
+----
+2
+
+query I
+SELECT rtrim(content, chr(10)) FROM read_text('git://test/tmp/staged-glob-repo/*.md@STAGED');
+----
+staged
+
+# The same file at HEAD still reads the committed content
+query I
+SELECT rtrim(content, chr(10)) FROM read_text('git://test/tmp/staged-glob-repo/*.md@HEAD');
+----
+committed
+
+# A pseudo-ref followed by a directory-scoped glob. WORKDIR and STAGED are not
+# git refs, so the revision/path split cannot be settled by asking the
+# repository to resolve them: this used to raise
+# "revspec 'STAGED/src' not found", leaving only top-level globs usable.
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@WORKDIR/src/*.py');
+----
+2
+
+query I
+SELECT COUNT(*) FROM glob('git://test/tmp/staged-glob-repo@WORKDIR/**/*.py');
+----
+2


### PR DESCRIPTION
Triage of the #26 umbrella. **Every one of its four findings was already fixed** — all four by `c1b3e89`, "fix: keep slash-bearing refs intact in git:// URIs (#26)". I verified each rather than trusting the checkboxes, and then went looking in the same code for what the review had missed. Five live defects were there, four of them in the "wrong answer, no error" band the umbrella's own items were about.

### ⚠️ This PR is stacked on #45–#50

`review/26` branches off `origin/main` and merges all six open PRs before adding anything, so the diff below shows their commits too. **Merge this after #45–#50.** Building on plain `main` would have conflicted with unreviewed work in nearly every file in `src/`; the six were verified to merge cleanly and the combined tree passes **1057 assertions in 64 test cases**, which is the baseline every number here is measured against. My four commits are the ones tagged `(#26)` on top of the six merges.

## Triage of the umbrella's own items

| # | Finding | Verdict | Evidence |
|---|---|---|---|
| 1 | `GitFileSystem::ListFiles` is a stub; commit-tree globbing enumerates nothing | **already fixed** | `c1b3e89`. It walks the tree and matches per component; `test/sql/git_filesystem_tree_glob.test` covers it. |
| 2 | Slash-bearing refs truncate at the first `/` | **already fixed** | `c1b3e89`. `test/sql/git_slash_refs.test`; `@feature/foo` and `@fix/deep/nested` resolve. |
| 3 | Remote LFS stub throws a hard error (the one item still unchecked) | **fixed as designed, and the real bug was next door** | The error is now deliberate, actionable and documented — but see "LFS" below: `git_read()` never detected a pointer at all and returned the pointer text as content. |
| 4 | README "smart pointers throughout" / stale "736 assertions in 46 test cases" | **already fixed** | `c1b3e89`. README now says libgit2 objects are raw C handles freed by their owner, and the assertion count is gone. |

## What was actually broken

Ranked by whether it produces a wrong answer with no error.

**1. `_each` functions ignore a ref passed through a LATERAL join.** DuckDB binds a table function two ways: all-literal arguments make it a `STANDARD_TABLE_FUNCTION` with `TableFunctionBindInput::inputs` populated; a correlated call is bound as `TABLE_IN_OUT_FUNCTION` and `inputs` is left **empty** — every argument arrives in the runtime `DataChunk`. `git_tree_each`, `git_log_each` and `git_diff_tree_each` read only `input.data[0]` and took the ref from bind data, so the ref was silently dropped for exactly the form the docs lead with:

```sql
SELECT l.commit_hash, t.file_path
FROM git_log() l, LATERAL git_tree_each('.', l.commit_hash) t;
```

Every commit reported as containing **HEAD's** tree. Measured on the fixture: `git_tree_each(repo,'feature/foo')` gives 4 rows with literals, 3 (main's tree) through LATERAL. Same shape in `docs/guide/lateral-joins.md` and a dozen places in `docs/examples/`. `git_diff_tree_each` was worse — with both refs dropped, `ref2` stayed empty, which is `CollectDiffRows`'s signal to diff against the **working directory**, so a LATERAL `v1.0..v2.0` request quietly answered HEAD-vs-dirty-worktree. `git_blame_each` already read its ref correctly; the other three now do the same.

`test/sql/git_each_integration.test` passed throughout, because its fixture has the same tree at all three commits.

**2. `git_read()` returns the LFS pointer as the file's content.** `docs/reference/git_read.md` says "Git LFS files are automatically detected and their real content is returned." It never looked. An LFS-tracked file came back as ~127 bytes of pointer text with `is_text=true, size_bytes=127` — a plausible small text file — while `read_text()` on the identical URI resolved the object. Two readers, same file, different content, no error from either. It did this even when the object *was* in the local store. This is issue #26's own LFS concern, one reader over.

**3. `max_bytes` silently reclassifies a text file as binary.** The cut was applied before the UTF-8 check, so where the budget landed decided the answer. On a file holding `café\n`: `git_read(uri)` → `is_text=true, text='café\n'`; `git_read(uri, 4)` → `is_text=false, encoding='binary', text=NULL`. The caller asked for four bytes of a plain text file and was told the file is binary. Classification now happens on the whole blob and the text is cut back to a character boundary.

**4. `@STAGED`/`@INDEX` globbing used literal prefix matching.** `StringUtil::StartsWith` against the raw pattern. A pattern with a wildcard is never a literal prefix, so `glob('git://repo@STAGED/**')` returned **0 rows** while the same pattern at `@HEAD` works. Zero rows is data — indistinguishable from a repository that has no matching file. In the other direction it over-matched: `git://repo/src/uti@STAGED` reported `src/util.py`, and the returned URI is re-openable, so content for a path nobody wrote flowed into the query. A URI with no path returned *every* index entry, so `read_csv('git://repo@STAGED')` fed every staged file to the CSV parser. The index branch now runs the same matcher `ListFiles` uses on a commit tree.

**5. `git_tree_each` ignored `ref_kind`, and pseudo-refs could not carry a path.** Two smaller ones found while fixing the above:
- `git_tree_each` called `ProcessSingleCommit` unconditionally and swallowed the failure, so `git_tree_each('git://.@WORKDIR')` returned 0 rows with no error while `git_tree()` on the same URI returned the full listing.
- The revision/path split is settled by asking the repository to resolve the longest prefix that works — and `WORKDIR`/`STAGED` are not git refs, so nothing ever resolved. `git://repo@STAGED/src/*.csv` failed with `revspec 'STAGED/src' not found` while `git://repo@STAGED/*.csv` worked. Only top-level globs were usable over the index or the worktree. This one was loud, not silent.

## Verification

Every fix was watched misbehaving on the merged base before it was written, and each carries a test that fails before and passes after. Baseline **1057 assertions / 64 test cases** → **1132 assertions / 68 test cases**, all passing, no existing assertion changed. `make format-check` passes. `test/scripts/lfs_oid_traversal_test.sh` still passes — and the LFS fix extends its OID validation to `git_read`, which now rejects a traversal-shaped oid instead of handing back the pointer text.

New fixtures are generators, matching the convention `setup_slash_refs_fixture.sh` established: `setup_staged_glob_fixture.sh` (an index holding more and different paths than HEAD, so no assertion can pass by accidentally reading the commit tree) and `setup_lfs_missing_object_fixture.sh` (one LFS object present in the local store, one deliberately absent — no dependency on git-lfs being installed or a remote being reachable).

## Found and not fixed here

Verified to exist, left alone to keep this reviewable — each is worth its own issue:

- **`git_read` and `git_tree` disagree on `is_text` for non-UTF-8 text.** `git_read` states in a comment that `git_blob_is_binary` is authoritative so the two agree, then re-classifies with its own full-content UTF-8 check. A Latin-1 file (no NUL bytes) is `is_text=true` from `git_tree` and `is_text=false, text=NULL` from `git_read`.
- **`text_diff_stats()` and `text_diff_lines()` return fabricated constants.** `text_diff_stats` never reads its argument and always returns `lines_added: 1, lines_removed: 1, lines_modified: 1`; `text_diff_lines` always returns the same three rows `Hello/World/DuckDB`. Registered, callable, answering with invented data. If these are placeholders they should throw.
- **`read_git_diff(path)` in its one-argument form can never succeed**, and turns the failure into a data row: it builds `path + "@HEAD"`, which only `GitFileSystem` understands, then catches the exception and returns it as `diff_text`. A query counting diffs counts it as a real one.
- **`git_tree(path, untracked := true)` at `@WORKDIR` filters untracked files by raw string prefix**, so `git_tree('git://./src@WORKDIR', untracked := true)` also lists `src_backup/notes.txt`. Same class as the `@STAGED` glob bug fixed here; the tracked path in the same function matches exactly.
- **`git_status()` and `git_diff_tree()` discard the path part of their first argument** — both parse it and keep only `repository_path` — whereas `git_tree` and `git_log` use it as a filter. Possibly intended; there is no reference doc for `git_status` to check against.
- **Whole-file workdir reads ignore the byte count `read()` returns.** Only bites above the 2 GiB Linux cap, where the tail would be silently zero-filled while `size_bytes` reports the stat size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
