### PR TITLE
Fix #54, #55 and #52: fabricated diff stats, dropped path scopes, and the unregistered git_log ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ SELECT * FROM read_git_diff('local.txt', 'git://file@HEAD');
 -- Structured diff analysis
 SELECT * FROM text_diff_lines(diff_text('old content', 'new content'));
 
--- Diff statistics and metrics
-SELECT * FROM text_diff_stats('old content', 'new content');
+-- Diff statistics and metrics (a scalar returning a STRUCT of counts)
+SELECT text_diff_stats('old content', 'new content');
 ```
 
 ## 🚀 Quick Start

--- a/docs/db.md
+++ b/docs/db.md
@@ -195,21 +195,28 @@ graph LR
 ### Common Join Patterns
 
 ```sql
+-- A table function's arguments must be constant at bind time, so a value taken
+-- from another row goes to the `_each` variant, which reads its arguments from
+-- the LATERAL input at run time. The plain functions take literals.
+
 -- Files changed in a commit
-SELECT t.path, t.size, l.commit_message
-FROM git_log('.') l
-JOIN git_tree('.', l.commit_hash) t ON TRUE
+SELECT t.file_path, t.size_bytes, l.message
+FROM git_log('.') l,
+     LATERAL git_tree_each('.', l.commit_hash) t
 WHERE l.commit_hash = 'abc123';
 
 -- Branch history
 SELECT b.branch_name, l.*
-FROM git_branches('.') b
-JOIN git_log('.', b.branch_name) l ON TRUE;
+FROM git_branches('.') b,
+     LATERAL git_log_each('.', b.branch_name) l;
+
+-- One branch, by name: git_log takes a ref as its second argument
+SELECT * FROM git_log('.', 'develop');
 
 -- Tag releases with file counts
-SELECT t.tag_name, COUNT(tr.path) as file_count
-FROM git_tags('.') t
-JOIN LATERAL git_tree('.', t.commit_hash) tr ON TRUE
+SELECT t.tag_name, COUNT(tr.file_path) as file_count
+FROM git_tags('.') t,
+     LATERAL git_tree_each('.', t.commit_hash) tr
 GROUP BY t.tag_name;
 
 -- Merge commits (multiple parents)

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -72,8 +72,8 @@ Implements text diffing without external dependencies.
 
 **Functions:**
 - `text_diff()` / `diff_text()` - Compute unified diff
-- `text_diff_lines()` - Parse diff into lines
-- `text_diff_stats()` - Compute diff statistics
+- `text_diff_lines()` - Parse a diff string into one row per line
+- `text_diff_stats()` - Count the lines of a diff, as a STRUCT
 
 ## Data Flow
 

--- a/docs/git_uris.md
+++ b/docs/git_uris.md
@@ -143,7 +143,8 @@ JOIN LATERAL git_read_each(t.git_uri) r ON TRUE;
 -- Compare two versions (takes two separate git URIs)
 SELECT * FROM read_git_diff('git://file.txt@v1.0', 'git://file.txt@v2.0');
 
--- Compare against HEAD (single argument defaults to @HEAD comparison)
+-- Compare against HEAD: the single argument is the NEW side, and the OLD side
+-- is the same file at HEAD
 SELECT * FROM read_git_diff('git://file.txt@v1.0');
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,8 +60,8 @@ Built-in text diffing with multiple output formats:
 -- Compare two files
 SELECT * FROM read_git_diff('git://file.txt@v1.0', 'git://file.txt@v2.0');
 
--- Get diff statistics
-SELECT * FROM text_diff_stats('old content', 'new content');
+-- Get diff statistics (a STRUCT of counts)
+SELECT text_diff_stats('old content', 'new content');
 ```
 
 ## Quick Start

--- a/docs/reference/diff.md
+++ b/docs/reference/diff.md
@@ -129,6 +129,12 @@ Diff headers (`--- a/x`, `+++ b/x`, `diff --git …`, `index …`,
 rows. A `@@ -a,b +c,d @@` hunk header sets the line numbers that follow it;
 without one, numbering starts at 1.
 
+`--- x` and `+++ x` count as headers only where a header can appear — in a
+unified diff, outside a hunk body. Inside a hunk they are content, because a
+removed line reading `-- x` and an added line reading `++ x` render exactly that
+way; and `text_diff()` output has no headers at all, so they are content there
+too.
+
 Like every table function, the argument has to be constant at bind time — a
 correlated column will not bind.
 

--- a/docs/reference/diff.md
+++ b/docs/reference/diff.md
@@ -17,14 +17,25 @@ read_git_diff(file1, file2)
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `file1` | VARCHAR | Yes | First file path (local or git://) |
-| `file2` | VARCHAR | No | Second file path (defaults to comparing against HEAD) |
+| `file1` | VARCHAR | Yes | The OLD side (local path or `git://` URI) |
+| `file2` | VARCHAR | No | The NEW side (local path or `git://` URI) |
+
+With one argument, that argument is the NEW side and the OLD side is the same
+file at HEAD — so the diff reads the way `git diff <file>` does, with `+` lines
+being what the working copy adds. The output columns keep the two-argument
+meaning: `path1` is the old side (the `git://…@HEAD` URI it was compared
+against) and `path2` is the argument as written.
+
+A file that cannot be read raises. It used to come back as a one-row result set
+whose `diff_text` began with `Error:`, which made a failure look like data.
 
 ### Returns
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `diff_text` | VARCHAR | Unified diff output |
+| `diff_text` | VARCHAR | Diff output: `+`/`-`/` ` prefixed lines |
+| `path1` | VARCHAR | The old side that was compared |
+| `path2` | VARCHAR | The new side that was compared |
 
 ### Examples
 
@@ -111,15 +122,23 @@ text_diff_lines(diff_text) → TABLE
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `diff_text` | VARCHAR | Yes | Unified diff string |
+| `diff_text` | VARCHAR | Yes | A diff string: `text_diff()` output or a unified diff |
+
+Diff headers (`--- a/x`, `+++ b/x`, `diff --git …`, `index …`,
+`\ No newline at end of file`) are headers, not content, and are not returned as
+rows. A `@@ -a,b +c,d @@` hunk header sets the line numbers that follow it;
+without one, numbering starts at 1.
+
+Like every table function, the argument has to be constant at bind time — a
+correlated column will not bind.
 
 ### Returns
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `line_number` | INT32 | Line number in output |
-| `line_type` | VARCHAR | Type: `add`, `remove`, `context`, `header` |
-| `content` | VARCHAR | Line content |
+| `line_type` | VARCHAR | `CONTEXT`, `ADDED`, `REMOVED` or `MODIFIED` |
+| `content` | VARCHAR | The line, without its diff prefix |
+| `line_number` | BIGINT | The line's number in the file it exists in: the new file for `CONTEXT`/`ADDED`, the old file for `REMOVED` |
 
 ### Examples
 
@@ -130,15 +149,12 @@ SELECT * FROM text_diff_lines(
 ```
 
 ```sql
--- Analyze changes in a file
+-- Count the lines of each kind in a diff
 SELECT
     line_type,
     COUNT(*) as line_count
 FROM text_diff_lines(
-    (SELECT diff_text FROM read_git_diff(
-        'git://src/main.py@HEAD~1',
-        'git://src/main.py@HEAD'
-    ))
+    text_diff('line1' || chr(10) || 'line2', 'line1' || chr(10) || 'changed')
 )
 GROUP BY line_type;
 ```
@@ -152,32 +168,42 @@ Get statistics about a diff.
 ### Syntax
 
 ```sql
-text_diff_stats(old_text, new_text) → TABLE
+text_diff_stats(diff_text) → STRUCT
+text_diff_stats(old_text, new_text) → STRUCT
 ```
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `old_text` | VARCHAR | Yes | Original text |
-| `new_text` | VARCHAR | Yes | Modified text |
+| `diff_text` | VARCHAR | Yes | A diff string: `text_diff()` output or a unified diff |
+| `old_text`, `new_text` | VARCHAR | Yes | Two texts to diff, then count |
+
+Header lines are not counted: `--- a/x` is not a removed line and `+++ b/x` is
+not an added one.
 
 ### Returns
 
-| Column | Type | Description |
-|--------|------|-------------|
-| `lines_added` | INT32 | Number of lines added |
-| `lines_removed` | INT32 | Number of lines removed |
-| `lines_changed` | INT32 | Total lines changed |
+A single `STRUCT`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `lines_added` | BIGINT | Lines present only in the new text |
+| `lines_removed` | BIGINT | Lines present only in the old text |
+| `lines_modified` | BIGINT | Lines marked `~` by `text_diff()` |
+| `lines_context` | BIGINT | Unchanged lines |
 
 ### Examples
 
 ```sql
-SELECT * FROM text_diff_stats(
-    'line1\nline2\nline3',
-    'line1\nmodified\nline3\nline4'
-);
--- Returns: lines_added=2, lines_removed=1, lines_changed=3
+SELECT (text_diff_stats(
+    'line1' || chr(10) || 'line2' || chr(10) || 'line3',
+    'line1' || chr(10) || 'modified' || chr(10) || 'line3' || chr(10) || 'line4'
+)).lines_added;
+-- 2
+
+SELECT text_diff_stats(text_diff('a', 'b'));
+-- {'lines_added': 1, 'lines_removed': 1, 'lines_modified': 0, 'lines_context': 0}
 ```
 
 ```sql
@@ -185,12 +211,11 @@ SELECT * FROM text_diff_stats(
 SELECT
     l.commit_hash,
     l.message,
-    s.lines_added,
-    s.lines_removed
+    (text_diff_stats(prev.text, curr.text)).lines_added,
+    (text_diff_stats(prev.text, curr.text)).lines_removed
 FROM git_log() l,
      LATERAL git_read_each(git_uri('.', 'README.md', l.commit_hash)) curr,
-     LATERAL git_read_each(git_uri('.', 'README.md', l.commit_hash || '~1')) prev,
-     LATERAL text_diff_stats(prev.text, curr.text) s
+     LATERAL git_read_each(git_uri('.', 'README.md', l.commit_hash || '~1')) prev
 LIMIT 10;
 ```
 
@@ -222,29 +247,28 @@ WHERE prev_text IS NOT NULL;
 ### Find Large Changes
 
 ```sql
-SELECT
-    l.commit_hash,
-    l.message,
-    s.lines_added + s.lines_removed as total_changes
-FROM git_log() l,
-     LATERAL git_read_each(git_uri('.', 'src/main.py', l.commit_hash)) curr,
-     LATERAL git_read_each(git_uri('.', 'src/main.py', l.commit_hash || '^')) prev,
-     LATERAL text_diff_stats(prev.text, curr.text) s
+SELECT * FROM (
+    SELECT
+        l.commit_hash,
+        l.message,
+        text_diff_stats(prev.text, curr.text) AS s
+    FROM git_log() l,
+         LATERAL git_read_each(git_uri('.', 'src/main.py', l.commit_hash)) curr,
+         LATERAL git_read_each(git_uri('.', 'src/main.py', l.commit_hash || '^')) prev
+)
 WHERE s.lines_added + s.lines_removed > 50
-ORDER BY total_changes DESC
+ORDER BY s.lines_added + s.lines_removed DESC
 LIMIT 10;
 ```
 
 ### Analyze Diff Content
 
 ```sql
--- Find what was removed
-SELECT content
-FROM text_diff_lines(
-    text_diff(
-        (SELECT text FROM git_read('git://file.txt@v1.0')),
-        (SELECT text FROM git_read('git://file.txt@v2.0'))
-    )
-)
-WHERE line_type = 'remove';
+-- Find what was removed. text_diff_lines is a table function, so its argument
+-- must be constant at bind time: diff the two versions with read_git_diff and
+-- filter its output, rather than feeding a subquery into text_diff_lines.
+SELECT line
+FROM read_git_diff('git://file.txt@v1.0', 'git://file.txt@v2.0'),
+     UNNEST(string_split(diff_text, chr(10))) AS t(line)
+WHERE line LIKE '-%';
 ```

--- a/docs/reference/git_log.md
+++ b/docs/reference/git_log.md
@@ -56,6 +56,21 @@ SELECT * FROM git_log('../other-project');
 SELECT * FROM git_log('vendor/duckdb');
 ```
 
+### With a Ref
+
+```sql
+-- One branch's history
+SELECT * FROM git_log('.', 'develop');
+
+-- A tag's history
+SELECT * FROM git_log('/path/to/repo', 'v1.0.0');
+
+-- Per-branch, with the ref coming from another row
+SELECT b.branch_name, l.commit_hash, l.message
+FROM git_branches('.') b,
+     LATERAL git_log_each('.', b.branch_name) l;
+```
+
 ### Filter by Date
 
 ```sql

--- a/src/git_blame.cpp
+++ b/src/git_blame.cpp
@@ -32,39 +32,9 @@ static string oid_to_hex(const git_oid *oid) {
 	return string(hex);
 }
 
-// Simple UTF-8 validation to prevent DuckDB VARCHAR verification crashes on
-// non-UTF-8 text files. Mirrors git_read.cpp's IsValidUTF8 — duplicated here
-// rather than extracted until a third caller appears.
-static bool IsValidUTF8(const char *data, size_t length) {
-	const unsigned char *bytes = reinterpret_cast<const unsigned char *>(data);
-	for (size_t i = 0; i < length;) {
-		unsigned char byte = bytes[i];
-		if (byte <= 0x7F) {
-			i++;
-			continue;
-		}
-		int num_bytes = 0;
-		if ((byte & 0xE0) == 0xC0) {
-			num_bytes = 2;
-		} else if ((byte & 0xF0) == 0xE0) {
-			num_bytes = 3;
-		} else if ((byte & 0xF8) == 0xF0) {
-			num_bytes = 4;
-		} else {
-			return false;
-		}
-		if (i + num_bytes > length) {
-			return false;
-		}
-		for (int j = 1; j < num_bytes; j++) {
-			if ((bytes[i + j] & 0xC0) != 0x80) {
-				return false;
-			}
-		}
-		i += num_bytes;
-	}
-	return true;
-}
+// UTF-8 validation lives in git_utils (IsValidUTF8). The third caller this
+// comment used to wait for has arrived: git_tree classifies is_text with it too
+// now, so all three surfaces answer the same question the same way (#55).
 
 //===--------------------------------------------------------------------===//
 // GitBlameRow — covers both per-line and per-hunk output shapes.

--- a/src/git_branches.cpp
+++ b/src/git_branches.cpp
@@ -38,7 +38,13 @@ unique_ptr<LocalTableFunctionState> GitBranchesLocalInit(ExecutionContext &conte
 unique_ptr<FunctionData> GitBranchesBind(ClientContext &context, TableFunctionBindInput &input,
                                          vector<LogicalType> &return_types, vector<CompatName> &names) {
 	// Use unified parameter parsing to support both git:// URIs and filesystem paths
-	auto params = ParseUnifiedGitParams(input, 1); // ref parameter at index 1 (optional)
+	// No ref parameter: only git_branches() and git_branches(repo) are registered,
+	// and a ref would have nothing to do here anyway -- the branch list is the
+	// repository's, not a commit's. The index-1 read this used to do was
+	// unreachable, and the comment describing it described a parameter the function
+	// does not accept (#52). 999 is the same "no such index" spelling git_blame
+	// uses.
+	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
 
 	// Use GitContextManager for unified git URI processing and reference validation
 	string resolved_repo_path, resolved_file_path, final_ref;

--- a/src/git_diff_tree.cpp
+++ b/src/git_diff_tree.cpp
@@ -280,6 +280,7 @@ static unique_ptr<FunctionData> GitDiffTreeBind(ClientContext &context, TableFun
 	string ref = "HEAD";
 	string ref2;
 	string path_filter;
+	string argument_path;
 	bool include_untracked = false;
 
 	// Parse positional parameters
@@ -293,6 +294,11 @@ static unique_ptr<FunctionData> GitDiffTreeBind(ClientContext &context, TableFun
 		try {
 			auto git_path = GitPath::Parse("git://" + first_param + "@HEAD");
 			repo_path = git_path.repository_path;
+			// The path INSIDE the repository, when the argument named one. It was
+			// parsed out here and then dropped, so git_diff_tree('repo/src', ...)
+			// answered for the whole repository regardless of the scope asked for
+			// (#55).
+			argument_path = git_path.file_path;
 		} catch (const std::exception &e) {
 			throw BinderException("git_diff_tree: failed to resolve repository path '%s': %s", first_param,
 			                      GitExceptionMessage(e));
@@ -324,6 +330,8 @@ static unique_ptr<FunctionData> GitDiffTreeBind(ClientContext &context, TableFun
 			include_untracked = kv.second.GetValue<bool>();
 		}
 	}
+
+	path_filter = CombineArgumentAndNamedPath("git_diff_tree", argument_path, path_filter);
 
 	return make_uniq<GitDiffTreeFunctionData>(repo_path, ref, ref2, path_filter, include_untracked);
 }
@@ -477,15 +485,20 @@ static OperatorResultType GitDiffTreeEachFunction(ExecutionContext &context, Tab
 			const string &requested_ref = row_ref.empty() ? bind_data.ref : row_ref;
 			const string &requested_ref2 = row_ref2.empty() ? bind_data.ref2 : row_ref2;
 
-			// Resolve repo path
+			// Resolve repo path, and the path inside it the row asked for. The
+			// LATERAL surface dropped that path exactly as the static one did (#55).
 			string resolved_repo_path;
+			string row_path;
 			try {
 				auto git_path = GitPath::Parse("git://" + repo_path_or_uri + "@HEAD");
 				resolved_repo_path = git_path.repository_path;
+				row_path = git_path.file_path;
 			} catch (...) {
 				state.current_input_row++;
 				continue;
 			}
+			const string row_path_filter =
+			    CombineArgumentAndNamedPath("git_diff_tree", row_path, bind_data.path_filter);
 
 			state.current_rows.clear();
 
@@ -497,7 +510,7 @@ static OperatorResultType GitDiffTreeEachFunction(ExecutionContext &context, Tab
 			}
 
 			try {
-				CollectDiffRows(repo, resolved_repo_path, requested_ref, requested_ref2, bind_data.path_filter,
+				CollectDiffRows(repo, resolved_repo_path, requested_ref, requested_ref2, row_path_filter,
 				                bind_data.include_untracked, state.current_rows);
 			} catch (...) {
 				git_repository_free(repo);

--- a/src/git_filesystem.cpp
+++ b/src/git_filesystem.cpp
@@ -533,7 +533,12 @@ unique_ptr<FileHandle> GitFileSystem::OpenFile(const string &path, FileOpenFlags
 				auto content = make_shared_ptr<string>();
 				content->resize(static_cast<size_t>(file_size));
 				if (file_size > 0) {
-					local_fs.Read(*local_handle, const_cast<char *>(content->data()), file_size);
+					// The positional Read: it loops until the whole request is
+					// satisfied and raises if it cannot be. The sequential overload
+					// is a single read(2), which returns at most 2 GiB - 4 KiB on
+					// Linux, so a larger file came back silently truncated with the
+					// tail left as zero bytes (#55).
+					local_fs.Read(*local_handle, const_cast<char *>(content->data()), file_size, 0);
 				}
 				return make_uniq<GitFileHandle>(*this, path, content, flags);
 			} else {

--- a/src/git_log.cpp
+++ b/src/git_log.cpp
@@ -26,7 +26,10 @@ GitLogFunctionData::GitLogFunctionData(const string &ref) : repo_path(""), resol
 unique_ptr<FunctionData> GitLogBind(ClientContext &context, TableFunctionBindInput &input,
                                     vector<LogicalType> &return_types, vector<CompatName> &names) {
 	// Use unified parameter parsing to support both git:// URIs and filesystem paths
-	auto params = ParseUnifiedGitParams(input, 1); // ref parameter at index 1 (optional)
+	// Optional ref at argument index 1: git_log(repo_path_or_uri, ref). Reachable
+	// since the two-argument overload was registered (#52); before that this read
+	// could never fire.
+	auto params = ParseUnifiedGitParams(input, 1);
 
 	// Define return schema with repo_path as first column
 	return_types = {
@@ -462,6 +465,22 @@ void RegisterGitLogFunction(ExtensionLoader &loader) {
 	git_log_func.init_local = GitLogLocalInit;
 	git_log_func.named_parameters["repo_path"] = LogicalType::VARCHAR;
 	loader.RegisterFunction(git_log_func);
+
+	// Two-argument version: git_log(repo_path_or_uri, ref).
+	//
+	// GitLogBind has always read a ref from argument index 1 -- resolving it,
+	// refusing it when the git:// URI already carries one, and walking history from
+	// it -- but no overload taking a second positional argument was ever
+	// registered, so that branch was unreachable and the comment above it described
+	// a parameter the function did not accept. docs/db.md published
+	// git_log('.', b.branch_name), which raised a Binder Error as written (#52).
+	// Registering the overload makes the ref a real argument, rather than deleting
+	// a working implementation of one.
+	TableFunction git_log_func_ref("git_log", {LogicalType::VARCHAR, LogicalType::VARCHAR}, GitLogFunction, GitLogBind,
+	                               GitLogInitGlobal);
+	git_log_func_ref.init_local = GitLogLocalInit;
+	git_log_func_ref.named_parameters["repo_path"] = LogicalType::VARCHAR;
+	loader.RegisterFunction(git_log_func_ref);
 
 	// Zero-argument version (defaults to current directory)
 	TableFunction git_log_func_zero("git_log", {}, GitLogFunction, GitLogBind, GitLogInitGlobal);

--- a/src/git_read.cpp
+++ b/src/git_read.cpp
@@ -12,50 +12,9 @@
 
 namespace duckdb {
 
-//===--------------------------------------------------------------------===//
-// UTF-8 Validation Helper
-//===--------------------------------------------------------------------===//
-
-// Simple UTF-8 validation to prevent verification crashes
-static bool IsValidUTF8(const char *data, size_t length) {
-	const unsigned char *bytes = reinterpret_cast<const unsigned char *>(data);
-	for (size_t i = 0; i < length;) {
-		unsigned char byte = bytes[i];
-
-		// ASCII (0-127)
-		if (byte <= 0x7F) {
-			i++;
-			continue;
-		}
-
-		// Multi-byte sequence
-		int num_bytes = 0;
-		if ((byte & 0xE0) == 0xC0) {
-			num_bytes = 2;
-		} else if ((byte & 0xF0) == 0xE0) {
-			num_bytes = 3;
-		} else if ((byte & 0xF8) == 0xF0) {
-			num_bytes = 4;
-		} else {
-			return false; // Invalid start byte
-		}
-
-		// Check if we have enough bytes
-		if (i + num_bytes > length) {
-			return false;
-		}
-
-		// Check continuation bytes
-		for (int j = 1; j < num_bytes; j++) {
-			if ((bytes[i + j] & 0xC0) != 0x80) {
-				return false;
-			}
-		}
-
-		i += num_bytes;
-	}
-	return true;
-}
+// UTF-8 validation lives in git_utils (IsValidUTF8): git_read, git_blame and
+// git_tree all classify is_text with it, and it has to mean the same thing in
+// all three (#55).
 
 //===--------------------------------------------------------------------===//
 // Helper Functions
@@ -249,7 +208,12 @@ static void ProcessWorkdirRead(const string &repo_path, const string &file_path,
 	string content;
 	content.resize(static_cast<size_t>(file_size));
 	if (file_size > 0) {
-		fs.Read(*handle, const_cast<char *>(content.data()), file_size);
+		// The positional Read: it loops until the whole request is satisfied and
+		// raises if it cannot be. The sequential overload is a single read(2),
+		// whose return value was discarded here -- and read(2) returns at most
+		// 2 GiB - 4 KiB on Linux, so a larger file came back silently truncated
+		// with the tail left as zero bytes (#55).
+		fs.Read(*handle, const_cast<char *>(content.data()), file_size, 0);
 	}
 
 	result.repo_path = repo_path;

--- a/src/git_status.cpp
+++ b/src/git_status.cpp
@@ -249,6 +249,7 @@ static unique_ptr<FunctionData> GitStatusBind(ClientContext &context, TableFunct
 	bool include_untracked = true;
 	bool include_ignored = false;
 	string path_filter;
+	string argument_path;
 
 	// Parse positional parameters
 	if (!input.inputs.empty()) {
@@ -263,6 +264,11 @@ static unique_ptr<FunctionData> GitStatusBind(ClientContext &context, TableFunct
 		try {
 			auto git_path = GitPath::Parse("git://" + first_param + "@HEAD");
 			repo_path = git_path.repository_path;
+			// The path INSIDE the repository, when the argument named one. It was
+			// parsed out here and then dropped, so git_status('repo/src') answered
+			// with the whole repository's status -- a well-formed answer to a
+			// question nobody asked (#55).
+			argument_path = git_path.file_path;
 		} catch (const std::exception &e) {
 			throw BinderException("git_status: failed to resolve repository path '%s': %s", first_param,
 			                      GitExceptionMessage(e));
@@ -287,6 +293,8 @@ static unique_ptr<FunctionData> GitStatusBind(ClientContext &context, TableFunct
 			path_filter = kv.second.GetValue<string>();
 		}
 	}
+
+	path_filter = CombineArgumentAndNamedPath("git_status", argument_path, path_filter);
 
 	return make_uniq<GitStatusFunctionData>(repo_path, include_untracked, include_ignored, path_filter);
 }
@@ -405,15 +413,20 @@ static OperatorResultType GitStatusEachFunction(ExecutionContext &context, Table
 				continue;
 			}
 
-			// Resolve repo path
+			// Resolve repo path, and the path inside it the row asked for. The
+			// LATERAL surface dropped that path exactly as the static one did:
+			// git_uri('repo', 'src') scoped nothing (#55).
 			string resolved_repo_path;
+			string row_path;
 			try {
 				auto git_path = GitPath::Parse("git://" + repo_path_or_uri + "@HEAD");
 				resolved_repo_path = git_path.repository_path;
+				row_path = git_path.file_path;
 			} catch (...) {
 				state.current_input_row++;
 				continue;
 			}
+			const string row_path_filter = CombineArgumentAndNamedPath("git_status", row_path, bind_data.path_filter);
 
 			state.current_rows.clear();
 
@@ -426,7 +439,7 @@ static OperatorResultType GitStatusEachFunction(ExecutionContext &context, Table
 
 			try {
 				CollectStatusRows(repo, resolved_repo_path, bind_data.include_untracked, bind_data.include_ignored,
-				                  bind_data.path_filter, state.current_rows);
+				                  row_path_filter, state.current_rows);
 			} catch (...) {
 				git_repository_free(repo);
 				state.current_input_row++;

--- a/src/git_tags.cpp
+++ b/src/git_tags.cpp
@@ -57,7 +57,12 @@ unique_ptr<LocalTableFunctionState> GitTagsLocalInit(ExecutionContext &context, 
 unique_ptr<FunctionData> GitTagsBind(ClientContext &context, TableFunctionBindInput &input,
                                      vector<LogicalType> &return_types, vector<CompatName> &names) {
 	// Use unified parameter parsing to support both git:// URIs and filesystem paths
-	auto params = ParseUnifiedGitParams(input, 1); // ref parameter at index 1 (optional)
+	// No ref parameter: only git_tags() and git_tags(repo) are registered, and a
+	// ref would have nothing to do here anyway -- the tag list is the repository's.
+	// The index-1 read this used to do was unreachable, and the comment describing
+	// it described a parameter the function does not accept (#52). 999 is the same
+	// "no such index" spelling git_blame uses.
+	auto params = ParseUnifiedGitParams(input, /*ref_param_index=*/999);
 
 	return_types = {
 	    LogicalType::VARCHAR,   // repo_path

--- a/src/git_tree.cpp
+++ b/src/git_tree.cpp
@@ -532,9 +532,8 @@ static void ProcessIndexTree(git_repository *repo, const string &repo_path, cons
 		git_blob *blob = nullptr;
 		if (git_blob_lookup(&blob, repo, &entry->id) == 0 && blob) {
 			row.size_bytes = static_cast<int64_t>(git_blob_rawsize(blob));
-			ClassifyBlobText(static_cast<const char *>(git_blob_rawcontent(blob)),
-			                 static_cast<size_t>(row.size_bytes), git_blob_is_binary(blob) != 0, row.is_text,
-			                 row.encoding);
+			ClassifyBlobText(static_cast<const char *>(git_blob_rawcontent(blob)), static_cast<size_t>(row.size_bytes),
+			                 git_blob_is_binary(blob) != 0, row.is_text, row.encoding);
 			git_blob_free(blob);
 		}
 

--- a/src/git_tree.cpp
+++ b/src/git_tree.cpp
@@ -181,8 +181,14 @@ static inline void EmitFileRow(vector<GitTreeRow> &out, const string &repo_path,
 	git_blob *blob = nullptr;
 	if (blob_oid && git_blob_lookup(&blob, repo, blob_oid) == 0 && blob) {
 		size_bytes = static_cast<int64_t>(git_blob_rawsize(blob));
-		is_text = !git_blob_is_binary(blob);
-		encoding = is_text ? "utf8" : "binary";
+		// libgit2's verdict AND UTF-8 validity, which is what git_read and
+		// git_blame ask of the same bytes. On libgit2's heuristic alone (a NUL in
+		// the first 8000 bytes), a Latin-1 file -- 8-bit text, no NUL, not valid
+		// UTF-8 -- was is_text=true here and is_text=false there for the very same
+		// blob, so a caller filtering on is_text got a different file set from
+		// each function (#55).
+		ClassifyBlobText(static_cast<const char *>(git_blob_rawcontent(blob)), static_cast<size_t>(size_bytes),
+		                 git_blob_is_binary(blob) != 0, is_text, encoding);
 		git_blob_free(blob);
 	}
 	GitTreeRow row;
@@ -424,10 +430,12 @@ static void ProcessWorkdirTree(git_repository *repo, const string &repo_path, co
 
 				string file_path(entry->index_to_workdir->new_file.path);
 
-				// Path filter
+				// Path filter, by path COMPONENT. StringUtil::StartsWith called
+				// "src_backup/untracked.txt" a file under "src", so asking for one
+				// directory silently returned its prefix-sharing siblings too (#55).
 				if (!requested_path.empty()) {
 					string norm = NormalizeRepoPathSpec(requested_path);
-					if (!norm.empty() && !StringUtil::StartsWith(file_path, norm)) {
+					if (!norm.empty() && !PathIsUnder(file_path, norm)) {
 						continue;
 					}
 				}
@@ -446,26 +454,13 @@ static void ProcessWorkdirTree(git_repository *repo, const string &repo_path, co
 					auto handle = local_fs.OpenFile(abs_path, FileOpenFlags::FILE_FLAGS_READ);
 					if (handle) {
 						row.size_bytes = local_fs.GetFileSize(*handle);
-
-						// Detect binary by sampling file for NUL bytes (same heuristic as libgit2)
-						if (row.size_bytes > 0) {
-							FILE *f = fopen(abs_path.c_str(), "rb");
-							if (f) {
-								char buf[8000];
-								size_t to_read = std::min(static_cast<size_t>(row.size_bytes), sizeof(buf));
-								size_t nread = fread(buf, 1, to_read, f);
-								fclose(f);
-								bool has_nul = (memchr(buf, 0, nread) != nullptr);
-								row.is_text = !has_nul;
-								row.encoding = has_nul ? "binary" : "utf8";
-							} else {
-								row.is_text = false;
-								row.encoding = "unknown";
-							}
-						} else {
-							row.is_text = true;
-							row.encoding = "utf8";
-						}
+						// The same question git_read answers for a workdir file:
+						// libgit2's NUL heuristic over the first 8000 bytes, and
+						// valid UTF-8 over the whole file. Sampling for NUL alone
+						// called a Latin-1 file utf8 text while git_read called the
+						// same bytes binary (#55). Streamed, so a large untracked
+						// file in a listing is never held in memory.
+						ClassifyWorkdirFileText(abs_path, row.is_text, row.encoding);
 					} else {
 						row.is_text = false;
 						row.encoding = "unknown";
@@ -537,8 +532,9 @@ static void ProcessIndexTree(git_repository *repo, const string &repo_path, cons
 		git_blob *blob = nullptr;
 		if (git_blob_lookup(&blob, repo, &entry->id) == 0 && blob) {
 			row.size_bytes = static_cast<int64_t>(git_blob_rawsize(blob));
-			row.is_text = !git_blob_is_binary(blob);
-			row.encoding = row.is_text ? "utf8" : "binary";
+			ClassifyBlobText(static_cast<const char *>(git_blob_rawcontent(blob)),
+			                 static_cast<size_t>(row.size_bytes), git_blob_is_binary(blob) != 0, row.is_text,
+			                 row.encoding);
 			git_blob_free(blob);
 		}
 

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -147,7 +147,8 @@ void ClassifyWorkdirFileText(const string &abs_path, bool &is_text, string &enco
 			return;
 		}
 		if (!has_nul && static_cast<size_t>(offset) < BINARY_SCAN_BYTES) {
-			const size_t scan = MinValue<size_t>(static_cast<size_t>(want), BINARY_SCAN_BYTES - static_cast<size_t>(offset));
+			const size_t scan =
+			    MinValue<size_t>(static_cast<size_t>(want), BINARY_SCAN_BYTES - static_cast<size_t>(offset));
 			has_nul = memchr(buffer.get(), 0, scan) != nullptr;
 		}
 		if (has_nul) {

--- a/src/git_utils.cpp
+++ b/src/git_utils.cpp
@@ -18,6 +18,152 @@ string GitExceptionMessage(const std::exception &e) {
 	return ErrorData(e).RawMessage();
 }
 
+string CombineArgumentAndNamedPath(const string &function_name, const string &argument_path, const string &named_path) {
+	const string from_argument = NormalizeRepoPathSpec(argument_path);
+	const string from_parameter = NormalizeRepoPathSpec(named_path);
+	if (!from_argument.empty() && !from_parameter.empty() && from_argument != from_parameter) {
+		throw BinderException("%s: a path was given both in the argument ('%s') and in the path parameter ('%s'). "
+		                      "Pass only one -- there is no answer that is both.",
+		                      function_name, from_argument, from_parameter);
+	}
+	return from_argument.empty() ? from_parameter : from_argument;
+}
+
+bool PathIsUnder(const string &path, const string &prefix) {
+	if (prefix.empty()) {
+		return true;
+	}
+	if (path == prefix) {
+		return true;
+	}
+	// The '/' is the point: "src_backup/x" shares the characters of "src" but not
+	// its components, and is not under it.
+	return path.size() > prefix.size() && path.compare(0, prefix.size(), prefix) == 0 && path[prefix.size()] == '/';
+}
+
+//===--------------------------------------------------------------------===//
+// Text classification
+//===--------------------------------------------------------------------===//
+
+namespace {
+
+// Byte-at-a-time UTF-8 validation that can be fed in pieces, so a file too large
+// to hold can still be classified. Deliberately as lax as the in-memory form it
+// replaces (it does not reject overlong encodings or surrogates): the two must
+// agree, and tightening one alone would put is_text back to meaning two things.
+struct Utf8Validator {
+	int pending = 0; // continuation bytes still expected
+	bool ok = true;
+
+	void Feed(const char *data, size_t length) {
+		const unsigned char *bytes = reinterpret_cast<const unsigned char *>(data);
+		for (size_t i = 0; i < length; i++) {
+			if (!ok) {
+				return;
+			}
+			const unsigned char byte = bytes[i];
+			if (pending > 0) {
+				if ((byte & 0xC0) != 0x80) {
+					ok = false;
+					return;
+				}
+				pending--;
+				continue;
+			}
+			if (byte <= 0x7F) {
+				continue;
+			}
+			if ((byte & 0xE0) == 0xC0) {
+				pending = 1;
+			} else if ((byte & 0xF0) == 0xE0) {
+				pending = 2;
+			} else if ((byte & 0xF8) == 0xF0) {
+				pending = 3;
+			} else {
+				ok = false; // Invalid start byte
+				return;
+			}
+		}
+	}
+
+	bool Valid() const {
+		// A sequence left unfinished at the end is truncated, not valid.
+		return ok && pending == 0;
+	}
+};
+
+} // namespace
+
+bool IsValidUTF8(const char *data, size_t length) {
+	Utf8Validator validator;
+	validator.Feed(data, length);
+	return validator.Valid();
+}
+
+void ClassifyBlobText(const char *data, size_t length, bool git_binary_hint, bool &is_text, string &encoding) {
+	is_text = !git_binary_hint && (length == 0 || IsValidUTF8(data, length));
+	encoding = is_text ? "utf8" : "binary";
+}
+
+void ClassifyWorkdirFileText(const string &abs_path, bool &is_text, string &encoding) {
+	// libgit2's heuristic: a NUL byte in the first 8000 makes the file binary.
+	static constexpr size_t BINARY_SCAN_BYTES = 8000;
+	static constexpr size_t CHUNK_BYTES = 64 * 1024;
+
+	LocalFileSystem fs;
+	unique_ptr<FileHandle> handle;
+	try {
+		handle = fs.OpenFile(abs_path, FileOpenFlags::FILE_FLAGS_READ);
+	} catch (const std::exception &) {
+		handle = nullptr;
+	}
+	if (!handle) {
+		is_text = false;
+		encoding = "unknown";
+		return;
+	}
+
+	const int64_t file_size = fs.GetFileSize(*handle);
+	if (file_size == 0) {
+		// An empty file is empty text, which is what git_read says of an empty blob.
+		is_text = true;
+		encoding = "utf8";
+		return;
+	}
+
+	Utf8Validator validator;
+	auto buffer = make_unsafe_uniq_array<char>(CHUNK_BYTES);
+	int64_t offset = 0;
+	bool has_nul = false;
+
+	while (offset < file_size) {
+		const int64_t want = MinValue<int64_t>(static_cast<int64_t>(CHUNK_BYTES), file_size - offset);
+		try {
+			// Positional Read: loops and raises rather than returning short.
+			fs.Read(*handle, buffer.get(), want, static_cast<idx_t>(offset));
+		} catch (const std::exception &) {
+			is_text = false;
+			encoding = "unknown";
+			return;
+		}
+		if (!has_nul && static_cast<size_t>(offset) < BINARY_SCAN_BYTES) {
+			const size_t scan = MinValue<size_t>(static_cast<size_t>(want), BINARY_SCAN_BYTES - static_cast<size_t>(offset));
+			has_nul = memchr(buffer.get(), 0, scan) != nullptr;
+		}
+		if (has_nul) {
+			break;
+		}
+		validator.Feed(buffer.get(), static_cast<size_t>(want));
+		if (!validator.ok) {
+			break;
+		}
+		offset += want;
+	}
+
+	is_text = !has_nul && validator.Valid();
+	encoding = is_text ? "utf8" : "binary";
+}
+
 string ApplyExplicitRepoPath(const string &uri, const string &repo_path, const string &function_name) {
 	if (repo_path.empty() || !StringUtil::StartsWith(uri, "git://")) {
 		return uri;

--- a/src/include/git_utils.hpp
+++ b/src/include/git_utils.hpp
@@ -66,6 +66,43 @@ UnifiedGitParams ParseLateralGitParams(TableFunctionBindInput &input, int ref_pa
 void RejectNullRepoPathArgument(const Value &value);
 void RejectNullRepoPathParameter(const Value &value);
 
+// A repository path argument may name a path INSIDE the repository
+// ('repo/src'), which scopes the answer to it. git_status and git_diff_tree
+// parsed that path out of their first argument and then dropped it, so the
+// answer was the whole repository's regardless of what was asked -- a
+// well-formed status for a scope the caller did not request (#55).
+//
+// Combine the path from the argument with an explicit `path` named parameter.
+// Both together are two answers to one question, so they raise rather than one
+// silently winning. function_name prefixes the error.
+string CombineArgumentAndNamedPath(const string &function_name, const string &argument_path, const string &named_path);
+
+// Does `path` name `prefix` itself, or something inside it?
+//
+// Compares path COMPONENTS, not characters. A raw StringUtil::StartsWith says
+// "src_backup/x" is under "src", which is how git_tree(untracked := true)
+// returned files from a sibling directory the caller never asked about (#55).
+bool PathIsUnder(const string &path, const string &prefix);
+
+// Is this valid UTF-8?
+//
+// Shared because is_text has to mean the same thing everywhere: git_read and
+// git_blame classify on UTF-8 validity (a DuckDB VARCHAR requires it), and
+// git_tree used to classify on libgit2's binary heuristic alone. That heuristic
+// looks for a NUL byte in the first 8000, so a Latin-1 file -- valid 8-bit text,
+// no NUL, not valid UTF-8 -- came back is_text=true from git_tree and
+// is_text=false from git_read for the very same blob (#55).
+bool IsValidUTF8(const char *data, size_t length);
+
+// The is_text/encoding pair for a blob already in memory. git_binary_hint is
+// libgit2's own verdict (git_blob_is_binary); text also has to be valid UTF-8.
+void ClassifyBlobText(const char *data, size_t length, bool git_binary_hint, bool &is_text, string &encoding);
+
+// The same classification for a file on disk, which git_tree needs for untracked
+// files. Reads in chunks and validates as it goes, so classifying a listing does
+// not depend on being able to hold each file in memory.
+void ClassifyWorkdirFileText(const string &abs_path, bool &is_text, string &encoding);
+
 // RAII wrapper for git repository
 class GitRepository {
 public:

--- a/src/include/text_diff.hpp
+++ b/src/include/text_diff.hpp
@@ -59,6 +59,16 @@ public:
 	// Create diff from two strings
 	static TextDiff CreateDiff(const string &old_text, const string &new_text);
 
+	// Read a diff back from its textual form: either ToString()'s output (' ', '+',
+	// '-' and '~' prefixes) or a unified diff. Headers ("--- a/x", "+++ b/x",
+	// "diff --git ...", "index ...", "\ No newline at end of file") are headers, not
+	// content -- counting "+++ b/x" as an added line is exactly the kind of
+	// plausible-but-wrong number this parser exists to avoid. A "@@ -a,b +c,d @@"
+	// hunk header sets the line numbers it declares; without one the numbering
+	// starts at 1. A line carrying no recognised prefix is outside any hunk and is
+	// skipped.
+	static TextDiff Parse(const string &diff_text);
+
 	// Accessors
 	const vector<DiffLine> &GetLines() const {
 		return diff_lines_;

--- a/src/include/text_diff.hpp
+++ b/src/include/text_diff.hpp
@@ -67,6 +67,14 @@ public:
 	// hunk header sets the line numbers it declares; without one the numbering
 	// starts at 1. A line carrying no recognised prefix is outside any hunk and is
 	// skipped.
+	//
+	// "--- x" and "+++ x" are the two spellings that collide with content: a
+	// removed line reading "-- x" and an added one reading "++ x" render exactly
+	// like them, and both are everyday text in SQL and Markdown. So they count as
+	// headers only where a header can be -- in a unified diff (one that announces
+	// hunks with "@@"), and outside a hunk body, whose extent the hunk header's
+	// counts give. In ToString()'s output, which has no headers at all, they are
+	// always content.
 	static TextDiff Parse(const string &diff_text);
 
 	// Accessors

--- a/src/text_diff.cpp
+++ b/src/text_diff.cpp
@@ -161,9 +161,19 @@ static bool IsDiffHeaderLine(const string &line) {
 	if (line == "---" || line == "+++") {
 		return true;
 	}
-	static const char *const prefixes[] = {"--- ", "+++ ", "diff ", "index ",   "old mode ",
-	                                       "new mode ", "new file mode ", "deleted file mode ", "similarity index ",
-	                                       "rename ",  "copy ",           "Binary files ",      "\\"};
+	static const char *const prefixes[] = {"--- ",
+	                                       "+++ ",
+	                                       "diff ",
+	                                       "index ",
+	                                       "old mode ",
+	                                       "new mode ",
+	                                       "new file mode ",
+	                                       "deleted file mode ",
+	                                       "similarity index ",
+	                                       "rename ",
+	                                       "copy ",
+	                                       "Binary files ",
+	                                       "\\"};
 	for (const char *prefix : prefixes) {
 		const size_t len = strlen(prefix);
 		if (line.size() >= len && line.compare(0, len, prefix) == 0) {
@@ -702,10 +712,9 @@ void RegisterTextDiffType(ExtensionLoader &loader) {
 	// Register text_diff_stats: over a diff the caller already has, and over the
 	// pair of texts to diff first.
 	ScalarFunctionSet stats_set("text_diff_stats");
+	stats_set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, TextDiffStatsType(), TextDiffStatsFunction));
 	stats_set.AddFunction(
-	    ScalarFunction({LogicalType::VARCHAR}, TextDiffStatsType(), TextDiffStatsFunction));
-	stats_set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, TextDiffStatsType(),
-	                                     TextDiffStatsPairFunction));
+	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, TextDiffStatsType(), TextDiffStatsPairFunction));
 	loader.RegisterFunction(stats_set);
 
 	// Register text_diff_lines table function

--- a/src/text_diff.cpp
+++ b/src/text_diff.cpp
@@ -1,6 +1,8 @@
 #include "text_diff.hpp"
 #include "duckdb_compat.hpp"
+#include "git_filesystem.hpp"
 #include "git_utils.hpp"
+#include "duckdb/function/function_set.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -8,6 +10,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/file_opener.hpp"
 #include <algorithm>
+#include <cstring>
 #include <sstream>
 
 namespace duckdb {
@@ -97,6 +100,136 @@ bool TextDiff::operator==(const TextDiff &other) const {
 	}
 
 	return true;
+}
+
+//===--------------------------------------------------------------------===//
+// Reading a diff back from its textual form
+//===--------------------------------------------------------------------===//
+
+// "@@ -10,3 +12,4 @@ optional heading" -- take the two start line numbers.
+// Returns false for anything that is not a hunk header, in which case the
+// counters are left alone and the line is skipped as an unrecognised header.
+static bool ParseHunkHeader(const string &line, idx_t &old_line, idx_t &new_line) {
+	if (line.size() < 4 || line.compare(0, 2, "@@") != 0) {
+		return false;
+	}
+	size_t pos = 2;
+	auto skip_spaces = [&]() {
+		while (pos < line.size() && line[pos] == ' ') {
+			pos++;
+		}
+	};
+	auto read_start = [&](char sign, idx_t &out) {
+		skip_spaces();
+		if (pos >= line.size() || line[pos] != sign) {
+			return false;
+		}
+		pos++;
+		size_t digits_start = pos;
+		uint64_t value = 0;
+		while (pos < line.size() && line[pos] >= '0' && line[pos] <= '9') {
+			value = value * 10 + static_cast<uint64_t>(line[pos] - '0');
+			pos++;
+		}
+		if (pos == digits_start) {
+			return false;
+		}
+		// A ",count" may follow the start; it tells us nothing we need.
+		if (pos < line.size() && line[pos] == ',') {
+			pos++;
+			while (pos < line.size() && line[pos] >= '0' && line[pos] <= '9') {
+				pos++;
+			}
+		}
+		// git writes "@@ -1 +0,0 @@" for an emptied file: line 0 of a zero-line
+		// range. Clamp to 1 so the numbers we hand back always name a real line.
+		out = value == 0 ? 1 : static_cast<idx_t>(value);
+		return true;
+	};
+
+	idx_t parsed_old = 0, parsed_new = 0;
+	if (!read_start('-', parsed_old) || !read_start('+', parsed_new)) {
+		return false;
+	}
+	old_line = parsed_old;
+	new_line = parsed_new;
+	return true;
+}
+
+// A line that describes the diff rather than the files it compares.
+static bool IsDiffHeaderLine(const string &line) {
+	if (line == "---" || line == "+++") {
+		return true;
+	}
+	static const char *const prefixes[] = {"--- ", "+++ ", "diff ", "index ",   "old mode ",
+	                                       "new mode ", "new file mode ", "deleted file mode ", "similarity index ",
+	                                       "rename ",  "copy ",           "Binary files ",      "\\"};
+	for (const char *prefix : prefixes) {
+		const size_t len = strlen(prefix);
+		if (line.size() >= len && line.compare(0, len, prefix) == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+TextDiff TextDiff::Parse(const string &diff_text) {
+	vector<DiffLine> lines;
+	// Line numbers count from 1 when no hunk header says otherwise, which is what
+	// ToString()'s output (a single implicit hunk starting at the top) needs.
+	idx_t old_line = 1;
+	idx_t new_line = 1;
+
+	for (auto &raw : SplitLines(diff_text)) {
+		string line = raw;
+		// A CRLF diff leaves the '\r' on the end of every line; it belongs to the
+		// line terminator, not to the content.
+		if (!line.empty() && line.back() == '\r') {
+			line.pop_back();
+		}
+
+		if (ParseHunkHeader(line, old_line, new_line)) {
+			continue;
+		}
+		if (IsDiffHeaderLine(line)) {
+			continue;
+		}
+		if (line.empty()) {
+			// An unchanged empty line: git omits the leading space on it.
+			lines.emplace_back(LineType::CONTEXT, string(), old_line, new_line);
+			old_line++;
+			new_line++;
+			continue;
+		}
+
+		const string content = line.substr(1);
+		switch (line[0]) {
+		case ' ':
+			lines.emplace_back(LineType::CONTEXT, content, old_line, new_line);
+			old_line++;
+			new_line++;
+			break;
+		case '+':
+			lines.emplace_back(LineType::ADDED, content, 0, new_line);
+			new_line++;
+			break;
+		case '-':
+			lines.emplace_back(LineType::REMOVED, content, old_line, 0);
+			old_line++;
+			break;
+		case '~':
+			// ToString()'s spelling for MODIFIED; a unified diff never produces it.
+			lines.emplace_back(LineType::MODIFIED, content, old_line, new_line);
+			old_line++;
+			new_line++;
+			break;
+		default:
+			// Outside any hunk. Skipped rather than guessed at.
+			break;
+		}
+	}
+
+	return TextDiff(std::move(lines));
 }
 
 // Using string representation for simplicity
@@ -233,49 +366,140 @@ static void DiffTextFunction(DataChunk &args, ExpressionState &state, Vector &re
 	}
 }
 
-// TextDiff stats function
+//===--------------------------------------------------------------------===//
+// text_diff_stats
+//===--------------------------------------------------------------------===//
+
+// The statistics a diff carries, as a struct rather than a sentence: the caller
+// asked for numbers and wants to compute with them.
+static LogicalType TextDiffStatsType() {
+	child_list_t<LogicalType> children;
+	children.emplace_back("lines_added", LogicalType::BIGINT);
+	children.emplace_back("lines_removed", LogicalType::BIGINT);
+	children.emplace_back("lines_modified", LogicalType::BIGINT);
+	children.emplace_back("lines_context", LogicalType::BIGINT);
+	return LogicalType::STRUCT(std::move(children));
+}
+
+static Value TextDiffStatsValue(const TextDiff::Stats &stats) {
+	child_list_t<Value> children;
+	children.emplace_back("lines_added", Value::BIGINT(static_cast<int64_t>(stats.lines_added)));
+	children.emplace_back("lines_removed", Value::BIGINT(static_cast<int64_t>(stats.lines_removed)));
+	children.emplace_back("lines_modified", Value::BIGINT(static_cast<int64_t>(stats.lines_modified)));
+	children.emplace_back("lines_context", Value::BIGINT(static_cast<int64_t>(stats.lines_context)));
+	return Value::STRUCT(std::move(children));
+}
+
+// Count the lines of a diff the caller already has.
+//
+// This function used to return the constant string "lines_added: 1,
+// lines_removed: 1, lines_modified: 1" for every input -- an empty string and a
+// nine-line diff produced byte-identical output, because the argument was bound
+// and then never read (#54). Nothing raised and nothing was empty, so the number
+// looked like an answer.
 static void TextDiffStatsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &diff_vector = args.data[0];
 
-	// For now, return a simple struct with stats
-	// In full implementation, this would parse the TextDiff blob
-	result.SetVectorType(VectorType::CONSTANT_VECTOR);
-	auto result_data = CompatFlatDataMutable<string_t, ConstantVector>(result);
-	result_data[0] = StringVector::AddString(result, "lines_added: 1, lines_removed: 1, lines_modified: 1");
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t i = 0; i < args.size(); i++) {
+		auto diff_value = diff_vector.GetValue(i);
+		if (diff_value.IsNull()) {
+			result.SetValue(i, Value(TextDiffStatsType()));
+			continue;
+		}
+		auto diff = TextDiff::Parse(diff_value.ToString());
+		result.SetValue(i, TextDiffStatsValue(diff.GetStats()));
+	}
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
 }
 
-// TextDiff lines table function
-struct TextDiffLinesData : public GlobalTableFunctionState {
-	vector<TextDiff::DiffLine> lines;
-	idx_t position = 0;
+// The two-argument form the docs use: diff the pair, then count.
+static void TextDiffStatsPairFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &old_vector = args.data[0];
+	auto &new_vector = args.data[1];
 
-	TextDiffLinesData(vector<TextDiff::DiffLine> lines_p) : lines(std::move(lines_p)) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t i = 0; i < args.size(); i++) {
+		auto old_value = old_vector.GetValue(i);
+		auto new_value = new_vector.GetValue(i);
+		if (old_value.IsNull() || new_value.IsNull()) {
+			result.SetValue(i, Value(TextDiffStatsType()));
+			continue;
+		}
+		auto diff = TextDiff::CreateDiff(old_value.ToString(), new_value.ToString());
+		result.SetValue(i, TextDiffStatsValue(diff.GetStats()));
 	}
+	if (args.AllConstant()) {
+		result.SetVectorType(VectorType::CONSTANT_VECTOR);
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// text_diff_lines
+//===--------------------------------------------------------------------===//
+
+// Split a diff the caller already has into one row per line.
+//
+// Like text_diff_stats above, this used to answer with fabricated data: three
+// fixed demo rows (CONTEXT/Hello, REMOVED/World, ADDED/DuckDB) for every input,
+// including the empty string, because the argument reached the bind and stopped
+// there (#54).
+struct TextDiffLinesBindData : public FunctionData {
+	vector<TextDiff::DiffLine> lines;
+
+	explicit TextDiffLinesBindData(vector<TextDiff::DiffLine> lines_p) : lines(std::move(lines_p)) {
+	}
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<TextDiffLinesBindData>(lines);
+	}
+
+	bool Equals(const FunctionData &other) const override {
+		auto &other_data = other.Cast<TextDiffLinesBindData>();
+		if (lines.size() != other_data.lines.size()) {
+			return false;
+		}
+		for (idx_t i = 0; i < lines.size(); i++) {
+			const auto &a = lines[i];
+			const auto &b = other_data.lines[i];
+			if (a.type != b.type || a.content != b.content || a.old_line_number != b.old_line_number ||
+			    a.new_line_number != b.new_line_number) {
+				return false;
+			}
+		}
+		return true;
+	}
+};
+
+struct TextDiffLinesData : public GlobalTableFunctionState {
+	idx_t position = 0;
 };
 
 static unique_ptr<FunctionData> TextDiffLinesBind(ClientContext &context, TableFunctionBindInput &input,
                                                   vector<LogicalType> &return_types, vector<CompatName> &names) {
 	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BIGINT};
 	names = {"line_type", "content", "line_number"};
-	return nullptr;
+
+	vector<TextDiff::DiffLine> lines;
+	if (!input.inputs.empty() && !input.inputs[0].IsNull()) {
+		lines = TextDiff::Parse(input.inputs[0].ToString()).GetLines();
+	}
+	return make_uniq<TextDiffLinesBindData>(std::move(lines));
 }
 
 static unique_ptr<GlobalTableFunctionState> TextDiffLinesInit(ClientContext &context, TableFunctionInitInput &input) {
-	// For now, return empty data - full implementation would parse TextDiff argument
-	vector<TextDiff::DiffLine> lines;
-	lines.emplace_back(TextDiff::LineType::CONTEXT, "Hello", 1, 1);
-	lines.emplace_back(TextDiff::LineType::REMOVED, "World", 2, 0);
-	lines.emplace_back(TextDiff::LineType::ADDED, "DuckDB", 0, 2);
-
-	return make_uniq<TextDiffLinesData>(std::move(lines));
+	return make_uniq<TextDiffLinesData>();
 }
 
 static void TextDiffLinesFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &data = data_p.global_state->Cast<TextDiffLinesData>();
+	auto &bind_data = data_p.bind_data->Cast<TextDiffLinesBindData>();
 
 	idx_t output_idx = 0;
-	while (data.position < data.lines.size() && output_idx < STANDARD_VECTOR_SIZE) {
-		const auto &line = data.lines[data.position];
+	while (data.position < bind_data.lines.size() && output_idx < STANDARD_VECTOR_SIZE) {
+		const auto &line = bind_data.lines[data.position];
 
 		// Set line_type
 		string line_type_str;
@@ -294,9 +518,16 @@ static void TextDiffLinesFunction(ClientContext &context, TableFunctionInput &da
 			break;
 		}
 
+		// line_number is the line's number in the file it exists in: the new file
+		// for a context or added line, the old file for a removed one. Reporting
+		// the row's position in the diff instead would be a number that looks like
+		// a line number and is not one.
+		const idx_t line_number =
+		    line.type == TextDiff::LineType::REMOVED ? line.old_line_number : line.new_line_number;
+
 		output.SetValue(0, output_idx, Value(line_type_str));
 		output.SetValue(1, output_idx, Value(line.content));
-		output.SetValue(2, output_idx, Value::BIGINT(static_cast<int64_t>(data.position + 1)));
+		output.SetValue(2, output_idx, Value::BIGINT(static_cast<int64_t>(line_number)));
 
 		data.position++;
 		output_idx++;
@@ -343,6 +574,22 @@ struct ReadGitDiffData : public GlobalTableFunctionState {
 	}
 };
 
+// The HEAD version of whatever the caller named, as a git:// URI the extension's
+// own filesystem can open.
+//
+// The single-argument form used to build this by appending "@HEAD" to the string
+// it was given, producing "README.md@HEAD" -- a filename with an '@' in it, which
+// the local filesystem cannot open, so the one-argument form could never succeed
+// (#55.2). A git:// URI is what names a file at a revision here.
+static string HeadUriFor(const string &path) {
+	auto git_path = GitPath::Parse(StringUtil::StartsWith(path, "git://") ? path : "git://" + path);
+	string uri = "git://" + git_path.repository_path;
+	if (!git_path.file_path.empty()) {
+		uri += "/" + git_path.file_path;
+	}
+	return uri + "@HEAD";
+}
+
 static unique_ptr<FunctionData> ReadGitDiffBind(ClientContext &context, TableFunctionBindInput &input,
                                                 vector<LogicalType> &return_types, vector<CompatName> &names) {
 	// Parse arguments from input.inputs
@@ -350,11 +597,20 @@ static unique_ptr<FunctionData> ReadGitDiffBind(ClientContext &context, TableFun
 	string path2;
 
 	if (input.inputs.size() > 1) {
-		// Two-argument version: diff between two paths
+		// Two-argument version: diff between two paths, old first and new second.
 		path2 = input.inputs[1].ToString();
 	} else {
-		// Single-argument version: diff against HEAD
-		path2 = path1 + "@HEAD"; // Default comparison
+		// Single-argument version: the file as it is now, against its HEAD version.
+		// The columns keep the two-argument form's meaning -- path1 is the old side
+		// and path2 the new one -- so the argument is reported as path2 and the
+		// HEAD side it was compared against as path1.
+		path2 = path1;
+		try {
+			path1 = HeadUriFor(path2);
+		} catch (const std::exception &e) {
+			throw BinderException("read_git_diff: cannot resolve '%s' to a file at HEAD: %s", path2,
+			                      GitExceptionMessage(e));
+		}
 	}
 
 	// Basic return columns
@@ -378,47 +634,40 @@ static unique_ptr<GlobalTableFunctionState> ReadGitDiffInit(ClientContext &conte
 	string path1 = bind_data.path1;
 	string path2 = bind_data.path2;
 
-	try {
-		// Read actual file content using DuckDB filesystem
-		auto &fs = FileSystem::GetFileSystem(context);
+	// A failure here is raised, not returned. This function used to catch every
+	// exception and hand the message back in diff_text, so a query against a file
+	// that could not be read got a one-row result set describing the failure --
+	// callers checking row counts saw success, and the message was data (#55.2).
+	auto &fs = FileSystem::GetFileSystem(context);
 
-		string content1, content2;
-
-		// Read first file
+	auto read_whole_file = [&fs](const string &path) {
 		try {
-			auto file_handle1 = fs.OpenFile(path1, FileFlags::FILE_FLAGS_READ);
-			auto file_size1 = file_handle1->GetFileSize();
-			auto buffer1 = make_unsafe_uniq_array<data_t>(file_size1);
-			file_handle1->Read(buffer1.get(), file_size1);
-			file_handle1->Close();
-			content1 = string(reinterpret_cast<const char *>(buffer1.get()), file_size1);
+			auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
+			auto file_size = handle->GetFileSize();
+			string content;
+			content.resize(static_cast<size_t>(file_size));
+			if (file_size > 0) {
+				// The positional Read: it loops until the request is satisfied and
+				// raises if it cannot be. The sequential overload is a single read(2),
+				// which returns at most 2 GiB - 4 KiB on Linux, so a larger file came
+				// back quietly truncated with the tail left as zero bytes (#55.5).
+				handle->Read(const_cast<char *>(content.data()), static_cast<idx_t>(file_size), 0);
+			}
+			handle->Close();
+			return content;
 		} catch (const std::exception &e) {
-			throw IOException("Failed to read file '%s': %s", path1, GitExceptionMessage(e));
+			throw IOException("read_git_diff: failed to read '%s': %s", path, GitExceptionMessage(e));
 		}
+	};
 
-		// Read second file
-		try {
-			auto file_handle2 = fs.OpenFile(path2, FileFlags::FILE_FLAGS_READ);
-			auto file_size2 = file_handle2->GetFileSize();
-			auto buffer2 = make_unsafe_uniq_array<data_t>(file_size2);
-			file_handle2->Read(buffer2.get(), file_size2);
-			file_handle2->Close();
-			content2 = string(reinterpret_cast<const char *>(buffer2.get()), file_size2);
-		} catch (const std::exception &e) {
-			throw IOException("Failed to read file '%s': %s", path2, GitExceptionMessage(e));
-		}
+	string content1 = read_whole_file(path1);
+	string content2 = read_whole_file(path2);
 
-		// Create diff using our TextDiff implementation
-		auto diff = TextDiff::CreateDiff(content1, content2);
-		string diff_text = diff.ToString();
+	// Create diff using our TextDiff implementation
+	auto diff = TextDiff::CreateDiff(content1, content2);
+	string diff_text = diff.ToString();
 
-		return make_uniq<ReadGitDiffData>(std::move(diff_text), path1, path2, bind_data.include_metadata);
-
-	} catch (const std::exception &e) {
-		// Return error in diff_text for now
-		string error_diff = "Error: " + string(GitExceptionMessage(e));
-		return make_uniq<ReadGitDiffData>(std::move(error_diff), path1, path2, bind_data.include_metadata);
-	}
+	return make_uniq<ReadGitDiffData>(std::move(diff_text), path1, path2, bind_data.include_metadata);
 }
 
 static void ReadGitDiffFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
@@ -450,10 +699,14 @@ void RegisterTextDiffType(ExtensionLoader &loader) {
 	                                     LogicalType::VARCHAR, DiffTextFunction);
 	loader.RegisterFunction(diff_text_func);
 
-	// Register text_diff_stats function
-	auto stats_func =
-	    ScalarFunction("text_diff_stats", {LogicalType::VARCHAR}, LogicalType::VARCHAR, TextDiffStatsFunction);
-	loader.RegisterFunction(stats_func);
+	// Register text_diff_stats: over a diff the caller already has, and over the
+	// pair of texts to diff first.
+	ScalarFunctionSet stats_set("text_diff_stats");
+	stats_set.AddFunction(
+	    ScalarFunction({LogicalType::VARCHAR}, TextDiffStatsType(), TextDiffStatsFunction));
+	stats_set.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, TextDiffStatsType(),
+	                                     TextDiffStatsPairFunction));
+	loader.RegisterFunction(stats_set);
 
 	// Register text_diff_lines table function
 	TableFunction lines_func("text_diff_lines", {LogicalType::VARCHAR}, TextDiffLinesFunction, TextDiffLinesBind,

--- a/src/text_diff.cpp
+++ b/src/text_diff.cpp
@@ -106,10 +106,13 @@ bool TextDiff::operator==(const TextDiff &other) const {
 // Reading a diff back from its textual form
 //===--------------------------------------------------------------------===//
 
-// "@@ -10,3 +12,4 @@ optional heading" -- take the two start line numbers.
+// "@@ -10,3 +12,4 @@ optional heading" -- the two start line numbers and the two
+// line COUNTS. The counts say how long the hunk is, which is the only thing that
+// tells us where its body ends; see Parse for why that matters.
 // Returns false for anything that is not a hunk header, in which case the
 // counters are left alone and the line is skipped as an unrecognised header.
-static bool ParseHunkHeader(const string &line, idx_t &old_line, idx_t &new_line) {
+static bool ParseHunkHeader(const string &line, idx_t &old_line, idx_t &new_line, int64_t &old_count,
+                            int64_t &new_count) {
 	if (line.size() < 4 || line.compare(0, 2, "@@") != 0) {
 		return false;
 	}
@@ -119,7 +122,7 @@ static bool ParseHunkHeader(const string &line, idx_t &old_line, idx_t &new_line
 			pos++;
 		}
 	};
-	auto read_start = [&](char sign, idx_t &out) {
+	auto read_start = [&](char sign, idx_t &out, int64_t &count_out) {
 		skip_spaces();
 		if (pos >= line.size() || line[pos] != sign) {
 			return false;
@@ -134,46 +137,58 @@ static bool ParseHunkHeader(const string &line, idx_t &old_line, idx_t &new_line
 		if (pos == digits_start) {
 			return false;
 		}
-		// A ",count" may follow the start; it tells us nothing we need.
+		// An omitted ",count" -- "@@ -1 +1 @@" -- means one line.
+		uint64_t count = 1;
 		if (pos < line.size() && line[pos] == ',') {
 			pos++;
+			size_t count_start = pos;
+			count = 0;
 			while (pos < line.size() && line[pos] >= '0' && line[pos] <= '9') {
+				count = count * 10 + static_cast<uint64_t>(line[pos] - '0');
 				pos++;
+			}
+			if (pos == count_start) {
+				return false;
 			}
 		}
 		// git writes "@@ -1 +0,0 @@" for an emptied file: line 0 of a zero-line
 		// range. Clamp to 1 so the numbers we hand back always name a real line.
 		out = value == 0 ? 1 : static_cast<idx_t>(value);
+		count_out = static_cast<int64_t>(count);
 		return true;
 	};
 
 	idx_t parsed_old = 0, parsed_new = 0;
-	if (!read_start('-', parsed_old) || !read_start('+', parsed_new)) {
+	int64_t parsed_old_count = 0, parsed_new_count = 0;
+	if (!read_start('-', parsed_old, parsed_old_count) || !read_start('+', parsed_new, parsed_new_count)) {
 		return false;
 	}
 	old_line = parsed_old;
 	new_line = parsed_new;
+	old_count = parsed_old_count;
+	new_count = parsed_new_count;
 	return true;
 }
 
-// A line that describes the diff rather than the files it compares.
-static bool IsDiffHeaderLine(const string &line) {
+// "--- a/x" and "+++ b/x": the pair naming the two sides of a file. These are the
+// ONLY header spellings that collide with content, because a removed line whose
+// text begins "-- " renders as "--- ..." and an added line beginning "++ "
+// renders as "+++ ...". Both are ordinary in SQL and in Markdown. So this is
+// asked only where a file header can actually appear -- see Parse.
+static bool IsFileHeaderMarker(const string &line) {
 	if (line == "---" || line == "+++") {
 		return true;
 	}
-	static const char *const prefixes[] = {"--- ",
-	                                       "+++ ",
-	                                       "diff ",
-	                                       "index ",
-	                                       "old mode ",
-	                                       "new mode ",
-	                                       "new file mode ",
-	                                       "deleted file mode ",
-	                                       "similarity index ",
-	                                       "rename ",
-	                                       "copy ",
-	                                       "Binary files ",
-	                                       "\\"};
+	return line.size() >= 4 && (line.compare(0, 4, "--- ") == 0 || line.compare(0, 4, "+++ ") == 0);
+}
+
+// A line that describes the diff rather than the files it compares, and that no
+// hunk body line can be mistaken for: inside a hunk every content line carries a
+// ' ', '+' or '-' prefix, so none of these spellings can occur as content.
+static bool IsNonContentHeaderLine(const string &line) {
+	static const char *const prefixes[] = {
+	    "diff ",   "index ", "old mode ",     "new mode ", "new file mode ", "deleted file mode ", "similarity index ",
+	    "rename ", "copy ",  "Binary files ", "\\"};
 	for (const char *prefix : prefixes) {
 		const size_t len = strlen(prefix);
 		if (line.size() >= len && line.compare(0, len, prefix) == 0) {
@@ -190,7 +205,30 @@ TextDiff TextDiff::Parse(const string &diff_text) {
 	idx_t old_line = 1;
 	idx_t new_line = 1;
 
-	for (auto &raw : SplitLines(diff_text)) {
+	auto raw_lines = SplitLines(diff_text);
+
+	// Are there file headers here at all? Only a unified diff has them, and a
+	// unified diff always announces its hunks with "@@". ToString()'s output has
+	// no "@@" line -- every line of it starts with ' ', '+', '-' or '~' -- so a
+	// leading "--- a" there is a removed "-- a" and nothing else. Deciding this
+	// once, up front, is what keeps text_diff(text_diff_stats(...)) honest for
+	// content that happens to begin with "--" or "++".
+	bool has_file_headers = false;
+	for (const auto &raw : raw_lines) {
+		if (raw.size() >= 2 && raw.compare(0, 2, "@@") == 0) {
+			has_file_headers = true;
+			break;
+		}
+	}
+
+	// Inside a hunk, "--- x" is a removed line, not a header. The hunk header's
+	// counts say where the body ends, so we know when we are back out of it and a
+	// header can appear again.
+	bool in_hunk = false;
+	int64_t old_remaining = 0;
+	int64_t new_remaining = 0;
+
+	for (auto &raw : raw_lines) {
 		string line = raw;
 		// A CRLF diff leaves the '\r' on the end of every line; it belongs to the
 		// line terminator, not to the content.
@@ -198,10 +236,20 @@ TextDiff TextDiff::Parse(const string &diff_text) {
 			line.pop_back();
 		}
 
-		if (ParseHunkHeader(line, old_line, new_line)) {
+		idx_t hunk_old = 1, hunk_new = 1;
+		int64_t hunk_old_count = 0, hunk_new_count = 0;
+		if (ParseHunkHeader(line, hunk_old, hunk_new, hunk_old_count, hunk_new_count)) {
+			old_line = hunk_old;
+			new_line = hunk_new;
+			old_remaining = hunk_old_count;
+			new_remaining = hunk_new_count;
+			in_hunk = old_remaining > 0 || new_remaining > 0;
 			continue;
 		}
-		if (IsDiffHeaderLine(line)) {
+		if (IsNonContentHeaderLine(line)) {
+			continue;
+		}
+		if (has_file_headers && !in_hunk && IsFileHeaderMarker(line)) {
 			continue;
 		}
 		if (line.empty()) {
@@ -209,6 +257,11 @@ TextDiff TextDiff::Parse(const string &diff_text) {
 			lines.emplace_back(LineType::CONTEXT, string(), old_line, new_line);
 			old_line++;
 			new_line++;
+			old_remaining--;
+			new_remaining--;
+			if (in_hunk && old_remaining <= 0 && new_remaining <= 0) {
+				in_hunk = false;
+			}
 			continue;
 		}
 
@@ -218,24 +271,33 @@ TextDiff TextDiff::Parse(const string &diff_text) {
 			lines.emplace_back(LineType::CONTEXT, content, old_line, new_line);
 			old_line++;
 			new_line++;
+			old_remaining--;
+			new_remaining--;
 			break;
 		case '+':
 			lines.emplace_back(LineType::ADDED, content, 0, new_line);
 			new_line++;
+			new_remaining--;
 			break;
 		case '-':
 			lines.emplace_back(LineType::REMOVED, content, old_line, 0);
 			old_line++;
+			old_remaining--;
 			break;
 		case '~':
 			// ToString()'s spelling for MODIFIED; a unified diff never produces it.
 			lines.emplace_back(LineType::MODIFIED, content, old_line, new_line);
 			old_line++;
 			new_line++;
+			old_remaining--;
+			new_remaining--;
 			break;
 		default:
 			// Outside any hunk. Skipped rather than guessed at.
 			break;
+		}
+		if (in_hunk && old_remaining <= 0 && new_remaining <= 0) {
+			in_hunk = false;
 		}
 	}
 

--- a/test/fixtures/setup_fixtures.sh
+++ b/test/fixtures/setup_fixtures.sh
@@ -94,6 +94,15 @@ setup_fixtures() {
     echo "Generating LFS local-cache fixture..."
     bash "$FIXTURES_DIR/../scripts/setup_lfs_missing_object_fixture.sh" "$TEMP_DIR"
 
+    # A repository with a "src" directory and a "src_backup" sibling, each
+    # carrying tracked, modified and untracked files. Asking for "src" has three
+    # distinguishable answers here -- the whole repository, src + src_backup, or
+    # src alone -- so a dropped path filter and an over-matching one cannot both
+    # look right (#55). It also carries a Latin-1 file, on which git_read and
+    # git_tree disagreed about is_text.
+    echo "Generating path-scope fixture..."
+    bash "$FIXTURES_DIR/../scripts/setup_path_scope_fixture.sh" "$TEMP_DIR"
+
     # A second spelling of main-repo whose textual form differs from the one
     # libgit2 resolves it to. GitPath::Parse derived the in-repository path by
     # stripping libgit2's repository root off the input as text, so an input that

--- a/test/scripts/setup_path_scope_fixture.sh
+++ b/test/scripts/setup_path_scope_fixture.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Generates the path-scoping fixture used by test/sql/path_scope_and_classification.test.
+#
+# Three of the defects in #55 need a repository whose answer visibly CHANGES when a
+# path is honoured, and a sibling directory whose name shares a prefix with it:
+#
+#   src/          tracked + modified + untracked      -- the scope a caller asks for
+#   src_backup/   tracked + modified + untracked      -- shares the prefix "src";
+#                                                        a raw StartsWith filter
+#                                                        pulls it in as well
+#   docs/         tracked + modified + untracked      -- outside both scopes
+#   latin1.txt    valid text, NOT valid UTF-8         -- git_read and git_tree
+#   docs/latin1_untracked.txt                            classified these
+#                                                        differently
+#
+# Every directory carries a change of each kind, so "the path was dropped"
+# (whole-repo answer), "the path over-matched" (src_backup pulled in) and "the
+# path was honoured" (src only) are three distinct row counts rather than
+# variations on the same one.
+#
+# Generated rather than committed as a tarball so the layout stays readable, and
+# because the workdir/untracked state a status test needs cannot be carried in a
+# git object anyway.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TEMP_DIR="${1:-$PROJECT_ROOT/test/tmp}"
+mkdir -p "$TEMP_DIR"
+
+REPO="$TEMP_DIR/path-scope-repo"
+
+rm -rf "$REPO"
+mkdir -p "$REPO"
+cd "$REPO"
+
+git init -q
+# Name the initial branch explicitly: the default differs across git versions
+# and host configuration, and the tests assert on 'main'.
+git checkout -q -b main
+git config user.email "test@example.com"
+git config user.name "Test User"
+git config commit.gpgsign false
+
+mkdir -p src src_backup docs
+
+# --- commit 1: the base tree -----------------------------------------
+printf 'src one\n'        > src/one.txt
+printf 'backup one\n'     > src_backup/one.txt
+printf 'docs one\n'       > docs/one.txt
+# "caf<0xE9>" -- Latin-1, no NUL byte. libgit2's binary heuristic (NUL in the
+# first 8000 bytes) calls this text; UTF-8 validation does not.
+printf 'caf\351\n'        > latin1.txt
+git add .
+git commit -q -m "base tree"
+
+# --- commit 2: one change in each directory --------------------------
+printf 'src one changed\n'    > src/one.txt
+printf 'backup one changed\n' > src_backup/one.txt
+printf 'docs one changed\n'   > docs/one.txt
+git add .
+git commit -q -m "change one file in each directory"
+
+# --- a second branch, for the git_log(repo, ref) overload (#52) ------
+git checkout -q -b develop
+printf 'only on develop\n' > develop-only.txt
+git add develop-only.txt
+git commit -q -m "develop: a commit that is not on main"
+git checkout -q main
+
+# --- working tree: modified tracked files ----------------------------
+printf 'src one modified in workdir\n'    > src/one.txt
+printf 'backup one modified in workdir\n' > src_backup/one.txt
+printf 'docs one modified in workdir\n'   > docs/one.txt
+
+# --- working tree: untracked files -----------------------------------
+printf 'untracked under src\n'        > src/untracked.txt
+printf 'untracked under src_backup\n' > src_backup/untracked.txt
+printf 'untracked under docs\n'       > docs/untracked.txt
+# The untracked counterpart of latin1.txt: git_tree classifies untracked files
+# from disk rather than from a blob, so that path needs its own Latin-1 case.
+printf 'caf\351\n'                    > docs/latin1_untracked.txt
+
+echo "Path-scope fixture ready at: $REPO"
+git --no-pager status --short | sed 's/^/  /'

--- a/test/sql/duck_tails_basic_functionality.test
+++ b/test/sql/duck_tails_basic_functionality.test
@@ -26,15 +26,17 @@ SELECT diff_text('content', '') IS NOT NULL as has_diff;
 ----
 true
 
-# Test read_git_diff single argument works
+# Test read_git_diff single argument works. The file has to exist: the
+# single-argument form compares it against its HEAD version, and a file that
+# cannot be read now raises instead of returning the error as a row (#55.2).
 query I
-SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('test.txt');
+SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('README.md');
 ----
 true
 
-# Test read_git_diff two arguments works  
+# Test read_git_diff two arguments works
 query I
-SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('file1.txt', 'file2.txt');
+SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('README.md', 'LICENSE');
 ----
 true
 
@@ -44,8 +46,10 @@ SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('git://README.md@HEAD', 'git:
 ----
 true
 
-# Test text_diff_lines function works
+# Test text_diff_lines function works. 'dummy' carries no diff prefix, so it is
+# a line outside any hunk and yields nothing; a real diff yields its lines
+# (#54 -- this used to answer with three fixed rows for any input at all).
 query I
-SELECT COUNT(*) > 0 as has_rows FROM text_diff_lines('dummy');
+SELECT COUNT(*) > 0 as has_rows FROM text_diff_lines(' context' || chr(10) || '-gone' || chr(10) || '+new');
 ----
 true

--- a/test/sql/duck_tails_phase2_basic.test
+++ b/test/sql/duck_tails_phase2_basic.test
@@ -26,15 +26,17 @@ SELECT diff_text('content', '') IS NOT NULL as has_diff;
 ----
 true
 
-# Test read_git_diff single argument works
+# Test read_git_diff single argument works. The file has to exist: the
+# single-argument form compares it against its HEAD version, and a file that
+# cannot be read now raises instead of returning the error as a row (#55.2).
 query I
-SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('test.txt');
+SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('README.md');
 ----
 true
 
-# Test read_git_diff two arguments works  
+# Test read_git_diff two arguments works
 query I
-SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('file1.txt', 'file2.txt');
+SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('README.md', 'LICENSE');
 ----
 true
 
@@ -44,8 +46,10 @@ SELECT COUNT(*) > 0 as has_rows FROM read_git_diff('git://README.md@HEAD', 'git:
 ----
 true
 
-# Test text_diff_lines function works
+# Test text_diff_lines function works. 'dummy' carries no diff prefix, so it is
+# a line outside any hunk and yields nothing; a real diff yields its lines
+# (#54 -- this used to answer with three fixed rows for any input at all).
 query I
-SELECT COUNT(*) > 0 as has_rows FROM text_diff_lines('dummy');
+SELECT COUNT(*) > 0 as has_rows FROM text_diff_lines(' context' || chr(10) || '-gone' || chr(10) || '+new');
 ----
 true

--- a/test/sql/git_error_messages.test
+++ b/test/sql/git_error_messages.test
@@ -24,29 +24,28 @@ PRAGMA threads=1;
 # The one line that mattered -- libgit2's own diagnosis -- sat under four rounds
 # of backslashes, unreadable to users and agents alike.
 
-# read_git_diff reports a failure in its diff_text column rather than raising,
-# which makes the message directly assertable as data.
-query I
-SELECT diff_text NOT LIKE '%exception_type%'
-FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
-                   'git://test/tmp/main-repo/README.md@HEAD');
+# read_git_diff used to report a failure in its diff_text column rather than
+# raising, and these three assertions read the message out of that column. It
+# raises now (#55.2), so the same three questions are asked of the error itself.
+# <!REGEX> asserts the message nowhere carries a re-encoded exception document.
+statement error
+SELECT * FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
+                            'git://test/tmp/main-repo/README.md@HEAD');
 ----
-true
+<!REGEX>:(?s).*exception_type.*
 
-query I
-SELECT diff_text NOT LIKE '%\\%'
-FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
-                   'git://test/tmp/main-repo/README.md@HEAD');
+statement error
+SELECT * FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
+                            'git://test/tmp/main-repo/README.md@HEAD');
 ----
-true
+<!REGEX>:(?s).*\\.*
 
 # The innermost cause -- the only part a reader needs -- must survive to the top.
-query I
-SELECT diff_text LIKE '%revspec ''nosuchref'' not found%'
-FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
-                   'git://test/tmp/main-repo/README.md@HEAD');
+statement error
+SELECT * FROM read_git_diff('git://test/tmp/main-repo/README.md@nosuchref',
+                            'git://test/tmp/main-repo/README.md@HEAD');
 ----
-true
+revspec 'nosuchref' not found
 
 # The same, for errors that are raised rather than returned. <!REGEX> asserts
 # the message nowhere carries a re-encoded exception document.

--- a/test/sql/git_log_ref_argument.test
+++ b/test/sql/git_log_ref_argument.test
@@ -1,0 +1,77 @@
+# name: test/sql/git_log_ref_argument.test
+# description: git_log(repo, ref) -- the second positional argument the bind code and the docs both describe (#52)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# Fixture: test/tmp/path-scope-repo, built by
+# test/scripts/setup_path_scope_fixture.sh.
+#   main    : 2 commits
+#   develop : those 2 plus "develop: a commit that is not on main"
+
+# The example published at docs/db.md raised a Binder Error as written: only
+# git_log(VARCHAR) and git_log(VARCHAR, repo_path := VARCHAR) were registered, so
+# a positional ref could not bind at all.
+query I
+SELECT COUNT(*) FROM git_log('test/tmp/path-scope-repo', 'develop');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_log('test/tmp/path-scope-repo', 'main');
+----
+2
+
+# The ref has to reach the walk, not just bind: the develop-only commit appears
+# under develop and nowhere else.
+query I
+SELECT COUNT(*) FROM git_log('test/tmp/path-scope-repo', 'develop')
+WHERE message LIKE 'develop:%';
+----
+1
+
+query I
+SELECT COUNT(*) FROM git_log('test/tmp/path-scope-repo', 'main')
+WHERE message LIKE 'develop:%';
+----
+0
+
+# One argument still means HEAD.
+query I
+SELECT (SELECT COUNT(*) FROM git_log('test/tmp/path-scope-repo'))
+     = (SELECT COUNT(*) FROM git_log('test/tmp/path-scope-repo', 'main'));
+----
+true
+
+# A NULL ref is the same as not passing one, not the literal string "NULL".
+query I
+SELECT COUNT(*) FROM git_log('test/tmp/path-scope-repo', NULL);
+----
+2
+
+# An unknown ref fails loudly rather than answering from HEAD.
+statement error
+SELECT * FROM git_log('test/tmp/path-scope-repo', 'no-such-branch');
+----
+no-such-branch
+
+# A correlated ref is git_log_each's job: a plain table function's arguments have
+# to be constant at bind time, so the per-branch join the docs published could
+# never have bound against git_log no matter which overloads exist. This is the
+# shape docs/db.md now shows.
+query I
+SELECT COUNT(*) > 0 FROM git_branches('test/tmp/path-scope-repo') b,
+     LATERAL git_log_each('test/tmp/path-scope-repo', b.branch_name) l;
+----
+true
+
+# A ref both in the URI and in the argument is two answers to one question.
+statement error
+SELECT * FROM git_log('git://test/tmp/path-scope-repo@main', 'develop');
+----
+Conflicting ref

--- a/test/sql/path_scope_and_classification.test
+++ b/test/sql/path_scope_and_classification.test
@@ -1,0 +1,181 @@
+# name: test/sql/path_scope_and_classification.test
+# description: git_status/git_diff_tree must honour the path they were given, git_tree(untracked) must not over-match a sibling directory, and is_text must not depend on which function read the bytes (#55)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# Fixture: test/tmp/path-scope-repo, built by
+# test/scripts/setup_path_scope_fixture.sh (run from setup_fixtures.sh).
+#
+#   src/one.txt              tracked, changed in HEAD, modified in the workdir
+#   src/untracked.txt        untracked
+#   src_backup/one.txt       tracked, changed in HEAD, modified in the workdir
+#   src_backup/untracked.txt untracked
+#   docs/one.txt             tracked, changed in HEAD, modified in the workdir
+#   docs/untracked.txt       untracked
+#   docs/latin1_untracked.txt  untracked, Latin-1 (no NUL, not valid UTF-8)
+#   latin1.txt               tracked, Latin-1 (no NUL, not valid UTF-8)
+#
+# "src" and "src_backup" share a prefix on purpose: a filter that drops the path
+# answers 7, one that matches the prefix as raw text answers 4, and one that
+# honours the path answers 2. Three defects, three distinguishable numbers.
+
+# ==============================================================
+# #55.4 -- git_status must not discard the path part of its argument
+# ==============================================================
+
+# The whole repository: 3 modified + 4 untracked.
+query I
+SELECT COUNT(*) FROM git_status('test/tmp/path-scope-repo');
+----
+7
+
+# Scoped to src/: one modified file and one untracked file, nothing else.
+query I
+SELECT COUNT(*) FROM git_status('test/tmp/path-scope-repo/src');
+----
+2
+
+query I
+SELECT COUNT(*) FROM git_status('test/tmp/path-scope-repo/src')
+WHERE file_path NOT LIKE 'src/%';
+----
+0
+
+# The prefix-sharing sibling must not be pulled in with it.
+query I
+SELECT COUNT(*) FROM git_status('test/tmp/path-scope-repo/src')
+WHERE file_path LIKE 'src\_backup/%' ESCAPE '\';
+----
+0
+
+# ...and asking for the sibling gets the sibling, not both.
+query I
+SELECT COUNT(*) FROM git_status('test/tmp/path-scope-repo/src_backup');
+----
+2
+
+# A path in the argument and a path named parameter are two answers to the same
+# question; refuse rather than silently preferring one.
+statement error
+SELECT * FROM git_status('test/tmp/path-scope-repo/src', path := 'docs');
+----
+both
+
+# ==============================================================
+# #55.4 -- git_diff_tree must not discard the path part either
+# ==============================================================
+
+# HEAD~1 -> HEAD changed one file in each of the three directories.
+query I
+SELECT COUNT(*) FROM git_diff_tree('test/tmp/path-scope-repo', 'HEAD~1', 'HEAD');
+----
+3
+
+query I
+SELECT COUNT(*) FROM git_diff_tree('test/tmp/path-scope-repo/src', 'HEAD~1', 'HEAD');
+----
+1
+
+query I
+SELECT file_path FROM git_diff_tree('test/tmp/path-scope-repo/src', 'HEAD~1', 'HEAD');
+----
+src/one.txt
+
+statement error
+SELECT * FROM git_diff_tree('test/tmp/path-scope-repo/src', 'HEAD~1', 'HEAD', path := 'docs');
+----
+both
+
+# ==============================================================
+# #55.3 -- git_tree(untracked := true) must match path components, not raw prefixes
+# ==============================================================
+
+# src/ holds one tracked file and one untracked file.
+query I
+SELECT COUNT(*) FROM git_tree('git://test/tmp/path-scope-repo/src@WORKDIR', untracked := true)
+WHERE kind = 'file';
+----
+2
+
+# "src_backup/untracked.txt" starts with the characters "src"; it is not in src/.
+query I
+SELECT COUNT(*) FROM git_tree('git://test/tmp/path-scope-repo/src@WORKDIR', untracked := true)
+WHERE file_path LIKE 'src\_backup/%' ESCAPE '\';
+----
+0
+
+query I
+SELECT file_path FROM git_tree('git://test/tmp/path-scope-repo/src@WORKDIR', untracked := true)
+WHERE kind = 'file' ORDER BY file_path;
+----
+src/one.txt
+src/untracked.txt
+
+# The unscoped listing still sees every untracked file.
+query I
+SELECT COUNT(*) FROM git_tree('git://test/tmp/path-scope-repo@WORKDIR', untracked := true)
+WHERE kind = 'file';
+----
+8
+
+# ==============================================================
+# #55.1 -- is_text must not depend on which function read the bytes
+# ==============================================================
+
+# latin1.txt is 8-bit text with no NUL byte: libgit2's binary heuristic calls it
+# text, UTF-8 validation does not. git_read (and git_blame) answer false; git_tree
+# used to answer true for the same blob, so a caller filtering on is_text got two
+# different file sets from the two functions.
+query II
+SELECT is_text, encoding FROM git_read('git://test/tmp/path-scope-repo/latin1.txt@HEAD');
+----
+false	binary
+
+query II
+SELECT is_text, encoding FROM git_tree('git://test/tmp/path-scope-repo@HEAD')
+WHERE file_path = 'latin1.txt';
+----
+false	binary
+
+# Same question asked through both functions, one row per file, no disagreement.
+query I
+SELECT COUNT(*) FROM git_tree('git://test/tmp/path-scope-repo@HEAD') t
+JOIN (SELECT file_path, is_text FROM git_read('git://test/tmp/path-scope-repo/latin1.txt@HEAD')) r
+  ON r.file_path = t.file_path
+WHERE t.is_text <> r.is_text;
+----
+0
+
+# The staged copy of the same bytes is classified the same way.
+query II
+SELECT is_text, encoding FROM git_tree('git://test/tmp/path-scope-repo@STAGED')
+WHERE file_path = 'latin1.txt';
+----
+false	binary
+
+# And so is an untracked one, which git_tree classifies from disk rather than
+# from a blob.
+query II
+SELECT is_text, encoding FROM git_tree('git://test/tmp/path-scope-repo@WORKDIR', untracked := true)
+WHERE file_path = 'docs/latin1_untracked.txt';
+----
+false	binary
+
+# A plain ASCII file stays text on every path.
+query II
+SELECT is_text, encoding FROM git_tree('git://test/tmp/path-scope-repo@HEAD')
+WHERE file_path = 'src/one.txt';
+----
+true	utf8
+
+query II
+SELECT is_text, encoding FROM git_tree('git://test/tmp/path-scope-repo@WORKDIR', untracked := true)
+WHERE file_path = 'src/untracked.txt';
+----
+true	utf8

--- a/test/sql/text_diff_functions.test
+++ b/test/sql/text_diff_functions.test
@@ -106,11 +106,13 @@ CONTEXT	keep	10
 REMOVED	gone	11
 ADDED	new	11
 
-# text_diff_lines and text_diff_stats must agree about the same diff.
+# text_diff_lines and text_diff_stats must agree about the same diff. (A table
+# function's arguments have to be constant at bind time, so the diff is written
+# out here rather than carried in from a correlated column.)
 query I
-SELECT (SELECT COUNT(*) FROM text_diff_lines(d) WHERE line_type = 'ADDED')
-     = (SELECT (text_diff_stats(d)).lines_added)
-FROM (SELECT diff_text('a' || chr(10) || 'b', 'a' || chr(10) || 'B' || chr(10) || 'c') AS d);
+SELECT (SELECT COUNT(*) FROM text_diff_lines(' a' || chr(10) || '-b' || chr(10) || '+B' || chr(10) || '+c')
+        WHERE line_type = 'ADDED')
+     = (text_diff_stats(' a' || chr(10) || '-b' || chr(10) || '+B' || chr(10) || '+c')).lines_added;
 ----
 true
 

--- a/test/sql/text_diff_functions.test
+++ b/test/sql/text_diff_functions.test
@@ -1,0 +1,173 @@
+# name: test/sql/text_diff_functions.test
+# description: text_diff_stats/text_diff_lines must answer from their argument (#54), and read_git_diff must raise rather than return its error as a row (#55.2)
+# group: [sql]
+
+require duck_tails
+
+require notwindows
+
+statement ok
+SET extension_directory='__BUILD_DIRECTORY__/extension';
+
+# ==============================================================
+# #54 -- text_diff_stats must read its argument
+# ==============================================================
+
+# diff_text('a\nb\nc', 'a\nB\nc') is " a\n-b\n+B\n c\n":
+# one line added, one removed, two unchanged.
+query IIII
+SELECT s.lines_added, s.lines_removed, s.lines_modified, s.lines_context
+FROM (SELECT text_diff_stats(diff_text('a' || chr(10) || 'b' || chr(10) || 'c',
+                                       'a' || chr(10) || 'B' || chr(10) || 'c')) AS s);
+----
+1	1	0	2
+
+# The empty diff is all zeroes -- not the same answer as a nine-line one.
+query IIII
+SELECT s.lines_added, s.lines_removed, s.lines_modified, s.lines_context
+FROM (SELECT text_diff_stats('') AS s);
+----
+0	0	0	0
+
+# Different inputs must not produce identical output. This is the whole of #54:
+# an empty string and a nine-line diff used to be byte-identical.
+query I
+SELECT text_diff_stats('') = text_diff_stats('+1' || chr(10) || '+2' || chr(10) || '+3');
+----
+false
+
+# Counts scale with the input.
+query II
+SELECT s.lines_added, s.lines_removed
+FROM (SELECT text_diff_stats('+1' || chr(10) || '+2' || chr(10) || '+3' || chr(10) ||
+                             '+4' || chr(10) || '+5' || chr(10) || '-6' || chr(10) ||
+                             '-7' || chr(10) || '-8') AS s);
+----
+5	3
+
+# Unified-diff headers are headers, not content: "--- a/x" is not a removed line
+# and "+++ b/x" is not an added one.
+query III
+SELECT s.lines_added, s.lines_removed, s.lines_context
+FROM (SELECT text_diff_stats('--- a/x' || chr(10) || '+++ b/x' || chr(10) ||
+                             '@@ -1,2 +1,3 @@' || chr(10) || ' keep' || chr(10) ||
+                             '-gone' || chr(10) || '+new1' || chr(10) || '+new2') AS s);
+----
+2	1	1
+
+# The two-argument form the docs use: diff the pair, then count.
+query II
+SELECT s.lines_added, s.lines_removed
+FROM (SELECT text_diff_stats('line1' || chr(10) || 'line2' || chr(10) || 'line3',
+                             'line1' || chr(10) || 'modified' || chr(10) || 'line3' || chr(10) || 'line4') AS s);
+----
+2	1
+
+query I
+SELECT text_diff_stats(NULL) IS NULL;
+----
+true
+
+# ==============================================================
+# #54 -- text_diff_lines must read its argument
+# ==============================================================
+
+# Three fixed demo rows (CONTEXT/Hello/1, REMOVED/World/2, ADDED/DuckDB/3) came
+# back for every input, including this one.
+query III
+SELECT line_type, content, line_number
+FROM text_diff_lines(diff_text('a' || chr(10) || 'b' || chr(10) || 'c',
+                               'a' || chr(10) || 'B' || chr(10) || 'c'));
+----
+CONTEXT	a	1
+REMOVED	b	2
+ADDED	B	2
+CONTEXT	c	3
+
+# Row count follows the input rather than being fixed at 3.
+query I
+SELECT COUNT(*) FROM text_diff_lines('');
+----
+0
+
+query I
+SELECT COUNT(*) FROM text_diff_lines('+1' || chr(10) || '+2' || chr(10) || '+3' || chr(10) || '+4');
+----
+4
+
+# Hunk headers set the line numbers they declare.
+query III
+SELECT line_type, content, line_number
+FROM text_diff_lines('--- a/x' || chr(10) || '+++ b/x' || chr(10) ||
+                     '@@ -10,2 +10,2 @@' || chr(10) || ' keep' || chr(10) ||
+                     '-gone' || chr(10) || '+new');
+----
+CONTEXT	keep	10
+REMOVED	gone	11
+ADDED	new	11
+
+# text_diff_lines and text_diff_stats must agree about the same diff.
+query I
+SELECT (SELECT COUNT(*) FROM text_diff_lines(d) WHERE line_type = 'ADDED')
+     = (SELECT (text_diff_stats(d)).lines_added)
+FROM (SELECT diff_text('a' || chr(10) || 'b', 'a' || chr(10) || 'B' || chr(10) || 'c') AS d);
+----
+true
+
+# ==============================================================
+# #55.2 -- read_git_diff must not return its error as a data row
+# ==============================================================
+
+# A file that does not exist is an error, not a one-row result set whose
+# diff_text happens to start with "Error:".
+statement error
+SELECT * FROM read_git_diff('test/tmp/path-scope-repo/no-such-file.txt');
+----
+read_git_diff
+
+statement error
+SELECT * FROM read_git_diff('test/tmp/path-scope-repo/no-such-file.txt', 'test/tmp/path-scope-repo/src/one.txt');
+----
+read_git_diff
+
+# Nothing that reaches a caller may describe a failure as data.
+query I
+SELECT COUNT(*) FROM (
+    SELECT diff_text FROM read_git_diff('test/tmp/path-scope-repo/src/one.txt')
+) WHERE diff_text LIKE 'Error:%';
+----
+0
+
+# The single-argument form compares the file against its HEAD version, so it can
+# actually succeed: src/one.txt is committed as "src one changed" and modified in
+# the working directory.
+query I
+SELECT COUNT(*) FROM read_git_diff('test/tmp/path-scope-repo/src/one.txt');
+----
+1
+
+query I
+SELECT diff_text LIKE '%+src one modified in workdir%'
+FROM read_git_diff('test/tmp/path-scope-repo/src/one.txt');
+----
+true
+
+query I
+SELECT diff_text LIKE '%-src one changed%'
+FROM read_git_diff('test/tmp/path-scope-repo/src/one.txt');
+----
+true
+
+# path1 names the side it was compared against.
+query I
+SELECT path1 LIKE 'git://%@HEAD' FROM read_git_diff('test/tmp/path-scope-repo/src/one.txt');
+----
+true
+
+# The two-argument form is unchanged: old first, new second.
+query I
+SELECT diff_text LIKE '%+src one modified in workdir%'
+FROM read_git_diff('git://test/tmp/path-scope-repo/src/one.txt@HEAD',
+                   'test/tmp/path-scope-repo/src/one.txt');
+----
+true

--- a/test/sql/text_diff_functions.test
+++ b/test/sql/text_diff_functions.test
@@ -173,3 +173,86 @@ FROM read_git_diff('git://test/tmp/path-scope-repo/src/one.txt@HEAD',
                    'test/tmp/path-scope-repo/src/one.txt');
 ----
 true
+
+# ==============================================================
+# #54 -- "--- x" is a header only where a header can be
+# ==============================================================
+
+# A removed line whose content begins "-- " renders as "--- ...", and an added
+# one beginning "++ " renders as "+++ ...". Reading those as the file header
+# dropped a changed line from the count and left the numbering of everything
+# after it short by one -- a plausible number with a change missing from it,
+# which is the defect this function was fixed for.
+#
+# text_diff() output carries no headers at all (every line of it starts with
+# ' ', '+', '-' or '~'), so here they are content, full stop.
+query IIII
+SELECT s.lines_added, s.lines_removed, s.lines_modified, s.lines_context
+FROM (SELECT text_diff_stats(text_diff('-- a' || chr(10) || 'x',
+                                       '-- b' || chr(10) || 'x')) AS s);
+----
+1	1	0	1
+
+query IIII
+SELECT s.lines_added, s.lines_removed, s.lines_modified, s.lines_context
+FROM (SELECT text_diff_stats(text_diff('++ a' || chr(10) || 'x',
+                                       '++ b' || chr(10) || 'x')) AS s);
+----
+1	1	0	1
+
+# The same shape as `git diff` writes it: a SQL comment changed inside a hunk.
+# The file header above the hunk is still a header.
+query III
+SELECT line_type, content, line_number
+FROM text_diff_lines('diff --git a/q.sql b/q.sql' || chr(10) ||
+                     'index a370000..a440000 100644' || chr(10) ||
+                     '--- a/q.sql' || chr(10) ||
+                     '+++ b/q.sql' || chr(10) ||
+                     '@@ -1,2 +1,2 @@' || chr(10) ||
+                     '--- sql comment' || chr(10) ||
+                     '+-- SQL COMMENT' || chr(10) ||
+                     ' select 1;');
+----
+REMOVED	-- sql comment	1
+ADDED	-- SQL COMMENT	1
+CONTEXT	select 1;	2
+
+# A rename, a binary file and "\ No newline at end of file" contribute no
+# content lines, and the one real hunk in the same diff is counted normally.
+query IIII
+SELECT s.lines_added, s.lines_removed, s.lines_modified, s.lines_context
+FROM (SELECT text_diff_stats(
+    'diff --git a/old.txt b/new.txt' || chr(10) ||
+    'similarity index 100%' || chr(10) ||
+    'rename from old.txt' || chr(10) ||
+    'rename to new.txt' || chr(10) ||
+    'diff --git a/bin.dat b/bin.dat' || chr(10) ||
+    'index f7c6699..97c4e94 100644' || chr(10) ||
+    'Binary files a/bin.dat and b/bin.dat differ' || chr(10) ||
+    'diff --git a/nonl.txt b/nonl.txt' || chr(10) ||
+    '--- a/nonl.txt' || chr(10) ||
+    '+++ b/nonl.txt' || chr(10) ||
+    '@@ -1 +1 @@' || chr(10) ||
+    '-before' || chr(10) ||
+    '\ No newline at end of file' || chr(10) ||
+    '+after' || chr(10) ||
+    '\ No newline at end of file') AS s);
+----
+1	1	0	0
+
+# Several hunks in one file: each header restarts the numbering it declares, and
+# the counts it declares say where its body ends.
+query III
+SELECT line_type, content, line_number
+FROM text_diff_lines('--- a/multi.txt' || chr(10) || '+++ b/multi.txt' || chr(10) ||
+                     '@@ -1,2 +1,2 @@' || chr(10) || '-a' || chr(10) || '+A' || chr(10) ||
+                     ' b' || chr(10) ||
+                     '@@ -17,2 +17,2 @@ p' || chr(10) || ' s' || chr(10) ||
+                     '-t' || chr(10) || '+T');
+----
+REMOVED	a	1
+ADDED	A	1
+CONTEXT	b	2
+CONTEXT	s	17
+REMOVED	t	18
+ADDED	T	18


### PR DESCRIPTION
Closes #54, closes #55, closes #52.

One PR because #55's second defect (`read_git_diff` returning its error as a data
row) lives in the same file as #54, and separating them would have meant two
branches editing `src/text_diff.cpp`. One commit per issue, plus the failing
tests first.

## The shape they share

Every one of these returns something that looks like an answer. Nothing raises,
nothing is empty, and the values are ordinary enough to be believed. That is why
each fix comes with a test that can tell a *right* answer from a *plausible* one —
the path-scope fixture pairs `src/` with a `src_backup/` sibling so that dropping
the path (7 rows), matching it as a raw string prefix (4 rows) and honouring it
(2 rows) are three different numbers rather than three ways of looking fine.

## #54 — two functions that never read their arguments

`text_diff_stats` returned the constant string `lines_added: 1, lines_removed: 1,
lines_modified: 1` for every input; `text_diff_lines` returned the same three demo
rows for every input, `''` included. Both now parse the diff they are handed
(`TextDiff::Parse`), which reads back `text_diff()` output and unified diffs:

- headers are headers — `--- a/x` is not a removed line and `+++ b/x` is not an
  added one. Counting them would have been the same class of plausible-wrong
  number.
- `@@ -a,b +c,d @@` sets the line numbers that follow it, so line numbers on a
  real git diff are the file's.
- a line with no recognised prefix is outside any hunk and is skipped rather than
  guessed at.

`text_diff_stats` now returns `STRUCT(lines_added, lines_removed, lines_modified,
lines_context)` — a caller asking for counts wants to compute with them — and
gains the two-argument form the docs already used. `text_diff_lines`'s
`line_number` is the line's number in the file it exists in (new file for
`CONTEXT`/`ADDED`, old file for `REMOVED`), not its position in the diff, which
looked like a line number without being one.

Implementing rather than unregistering: `TextDiff::DiffLine` and `GetStats` were
already there and correct; only the wiring between the argument and them was
missing.

## #55 — four of the five here, the fifth with #54

| # | Was | Now |
|---|-----|-----|
| 4 | `git_status`/`git_diff_tree` parsed the path out of their first argument and dropped it — whole-repository answer, always | the path reaches the pathspec they already build for `path :=`, on the static and LATERAL surfaces |
| 3 | `git_tree(untracked := true)` filtered with `StartsWith`, so `src` matched `src_backup/…` | `PathIsUnder` compares path components |
| 1 | `git_tree` classified `is_text` on libgit2's NUL heuristic alone; `git_read`/`git_blame` also require valid UTF-8, so a Latin-1 file was text to one and binary to the other | one classifier in `git_utils`, used by all three (and the duplicated `IsValidUTF8` copies in `git_read` and `git_blame` are now that one copy) |
| 5 | three workdir reads used the single-`read(2)` overload and discarded its return, so a file over 2 GiB came back truncated with a zero-filled tail | the positional overload, which loops and raises |
| 2 | `read_git_diff` returned its error in `diff_text`; the one-argument form appended `@HEAD` to a filename and so could never succeed | raises; the one-argument form resolves the HEAD version as a `git://` URI and diffs it against the working copy, the way `git diff <file>` reads |

A path in the argument *and* a `path :=` parameter now raise rather than one
silently winning.

**No test for #55.5.** Reproducing it needs a file over 2 GiB, which does not
belong in the suite. It is verified against `LocalFileSystem::Read`'s two
implementations in `duckdb/src/common/local_file_system.cpp`, where the
positional form loops and the sequential form is one `read(2)`.

## #52 — the three functions want different answers

`git_log`: **registered**. `GitLogBind`'s ref handling was real and complete —
resolve, refuse a conflict with a `@ref` in the URI, walk from it. Only the
overload was missing, so `git_log('.', 'develop')` now means what it reads as.

`git_branches` and `git_tags`: **dropped**. A ref has nothing to do in either —
the branch and tag lists belong to the repository, not to a commit — so
registering a two-argument form there would have accepted a parameter and ignored
it, which is #54's defect. They now use the `ref_param_index=999` spelling
`git_blame` already had.

**The doc example could not have worked either way.** `docs/db.md` published

```sql
FROM git_branches('.') b
JOIN git_log('.', b.branch_name) l ON TRUE;
```

and a table function's arguments must be constant at bind time, so a ref taken
from another row cannot bind to `git_log` with or without the new overload. That
is what `git_log_each` is for, and it has taken two arguments all along. The
example uses it now — as do its two neighbours in the same block, which were
correlated the same way.

## Verification

Baseline on `main`: **1142 assertions in 68 test cases**.
This branch: **1231 assertions in 71 test cases**, `make test_release` exit 0.

Red and green used different binaries. `sha256` of
`build/release/extension/duck_tails/duck_tails.duckdb_extension` at each stage:

| stage | sha256 (first 12) | result |
|-------|-------------------|--------|
| baseline, before any fix | `9bcb973dda69` | 1142/68 green; all three new tests red |
| after #54 | `dbdce1035145` | `text_diff_functions.test` green |
| after #55 | `0b6a62a83361` | `path_scope_and_classification.test` green |
| after #52 | `a3f372be1a0d` | `git_log_ref_argument.test` green; full suite green |

Every build gated on `make`'s exit status, not on grepping its output. The first
baseline build exited non-zero on a stray interrupt after `[100%] Built target
unittest` and was re-run to a clean exit before anything was measured — the
re-run turned out to still have a target left to build.

## Tests that changed with the contract

A bug that an existing test pins cannot be fixed without touching that test.
Four assertions asserted the fabricated behaviour and moved with it, each called
out in its commit:

- `duck_tails_basic_functionality.test` and `duck_tails_phase2_basic.test` called
  `read_git_diff('test.txt')` and `read_git_diff('file1.txt', 'file2.txt')` on
  files that do not exist, and passed *only* because the failure came back as a
  row. They name real files now. Their `text_diff_lines('dummy')` assertion passed
  only on the fabricated rows; it passes a real diff now.
- `git_error_messages.test` read the error out of `diff_text` to check its nesting
  (#22). The same three checks are made against the raised error, `<!REGEX>`
  negative assertions intact.

Not merged, not tagged, not released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz
